### PR TITLE
Fix incorrect argument to configure in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ module.exports = Zlib;
 Configure the Blacksmith default paths to the recipe, if not already configured in `config.json`, and then call the actual compilation command:
 
 ```
-$> blacksmith configure path.recipes /tmp/blacksmith-recipes/
+$> blacksmith configure paths.recipes /tmp/blacksmith-recipes/
 $> blacksmith containerized-build zlib@1.2.8:/tmp/tarballs/zlib-1.2.8.tar.gz
 blacksm INFO  Preparing build environment
 [...]

--- a/docs/Blacksmith.md
+++ b/docs/Blacksmith.md
@@ -340,7 +340,7 @@ module.exports = Zlib;
 We need to configure the Blacksmith default paths to the recipe and the source tarball (if not already configured in `config.json`) and then call the actual compilation command:
 
 ```
-$> blacksmith configure path.recipes /tmp/blacksmith-recipes/
+$> blacksmith configure paths.recipes /tmp/blacksmith-recipes/
 $> blacksmith containerized-build zlib:/tmp/tarballs/zlib-1.2.8
 blacksm INFO  Preparing build environment
 [...]
@@ -500,7 +500,7 @@ module.exports = Nginx;
 We need to configure the Blacksmith default paths to the recipe and the source tarball (if not already configured in `config.json`) and then call the actual compilation command:
 
 ```
-$> blacksmith configure path.recipes /tmp/blacksmith-recipes/
+$> blacksmith configure paths.recipes /tmp/blacksmith-recipes/
 $> blacksmith containerized-build zlib:/tmp/tarballs/zlib-1.2.8.tar.gz pcre:/tmp/tarballs/pcre-8.31.tar.gz openssl:/tmp/tarballs/openssl-1.0.2i.tar.gz nginx:/tmp/tarballs/nginx-1.10.1.tar.gz
 ```
 


### PR DESCRIPTION
Fixes T14333.

The argument to `configure` in the README was incorrectly specified as `path.recipes` however it should have been `paths.recipes`.