### PR TITLE
Avoid to spawn processes in tests when possible to show a more real coverage

### DIFF
--- a/test/build.js
+++ b/test/build.js
@@ -29,7 +29,7 @@ describe('#build()', function() {
     const test = helpers.createTestEnv();
     const component = helpers.createComponent(test);
     const componentFolder = `${component.id}-${component.version}`;
-    const res = blacksmithHandler.exec(
+    const res = blacksmithHandler.javascriptExec(path.join(__dirname, '../index.js'),
       `--config ${test.configFile} build --build-dir ${test.buildDir} ` +
       `${component.id}:${test.assetsDir}/${component.id}-${component.version}.tar.gz`);
     const artifact = glob.sync(path.join(
@@ -74,13 +74,14 @@ describe('#build()', function() {
     const test = helpers.createTestEnv();
     const component = helpers.createComponent(test);
     const componentFolder = `${component.id}-${component.version}`;
-    const res = blacksmithHandler.exec(`--log-level trace --log-file ${path.join(test.buildDir, 'test.log')} ` +
-    `--config ${test.configFile} ` +
-    'build --force-rebuild ' +
-    `--json ${component.buildSpecFile} ` +
-    '--incremental-tracking ' +
-    `--prefix ${test.buildDir} ` +
-    `--max-jobs ${jobs}`);
+    const res = blacksmithHandler.javascriptExec(path.join(__dirname, '../index.js'),
+      `--log-level trace --log-file ${path.join(test.buildDir, 'test.log')} ` +
+      `--config ${test.configFile} ` +
+      'build --force-rebuild ' +
+      `--json ${component.buildSpecFile} ` +
+      '--incremental-tracking ' +
+      `--prefix ${test.buildDir} ` +
+      `--max-jobs ${jobs}`);
     // Modifies the build ID
     expect(
       path.join(
@@ -91,7 +92,7 @@ describe('#build()', function() {
     ).to.be.file();
     expect(res.stdout).to.contain('Build completed. Artifacts stored');
     // Modifies the log level
-    expect(res.stdout).to.contain('blacksm TRACE ENVIRONMENT VARIABLES');
+    expect(res.stdout).to.match(/blacksm.*TRACE.*ENVIRONMENT VARIABLES/);
     // Set the log file
     expect(path.join(test.buildDir, 'test.log')).to.be.file();
     // Modifies the build directory

--- a/test/configure.js
+++ b/test/configure.js
@@ -35,21 +35,25 @@ describe('#configure', function() {
     return _.get(config, property);
   }
   it('It set a string property', function() {
-    blacksmithHandler.exec('configure compilation.prefix /tmp/test');
+    blacksmithHandler.javascriptExec(path.join(__dirname, '../index.js'),
+      'configure compilation.prefix /tmp/test');
     expect(check('compilation.prefix', '/tmp/test')).to.be.eql(true);
   });
   it('It set an array property', function() {
-    blacksmithHandler.exec('configure --action set paths.recipes /tmp/test');
+    blacksmithHandler.javascriptExec(path.join(__dirname, '../index.js'),
+      'configure --action set paths.recipes /tmp/test');
     expect(check('paths.recipes', ['/tmp/test'])).to.be.eql(true);
   });
 
   it('It adds a value to an array property', function() {
     const previousValue = get('paths.recipes');
-    blacksmithHandler.exec('configure --action add paths.recipes /tmp/test');
+    blacksmithHandler.javascriptExec(path.join(__dirname, '../index.js'),
+      'configure --action add paths.recipes /tmp/test');
     expect(check('paths.recipes', previousValue.concat('/tmp/test'))).to.be.eql(true);
   });
   it('It unset a property', function() {
-    blacksmithHandler.exec('configure --action unset compilation.prefix');
+    blacksmithHandler.javascriptExec(path.join(__dirname, '../index.js'),
+      'configure --action unset compilation.prefix');
     expect(get('compilation.prefix')).to.be.eql(null);
   });
 });

--- a/test/containerized-build.js
+++ b/test/containerized-build.js
@@ -33,7 +33,8 @@ describe('#containerized-build()', function() {
   it('Builds a simple package from CLI', function() {
     const test = helpers.createTestEnv(extraConf);
     const component = helpers.createComponent(test);
-    blacksmithHandler.exec(`--config ${test.configFile} ` +
+    blacksmithHandler.javascriptExec(path.join(__dirname, '../index.js'),
+      `--config ${test.configFile} ` +
       `containerized-build --build-dir ${test.buildDir} ` +
       `${component.id}:${test.assetsDir}/${component.id}-${component.version}.tar.gz`);
     expect(
@@ -55,7 +56,7 @@ describe('#containerized-build()', function() {
     });
     const component = helpers.createComponent(test);
     helpers.addComponentToMetadataServer(metadataServerEndpoint, component);
-    blacksmithHandler.exec(
+    blacksmithHandler.javascriptExec(path.join(__dirname, '../index.js'),
       `--config ${test.configFile} --log-level trace containerized-build --build-dir ${test.buildDir} ` +
       `${component.id}:${test.assetsDir}/${component.id}-${component.version}.tar.gz`);
     expect(
@@ -69,7 +70,8 @@ describe('#containerized-build()', function() {
     const test = helpers.createTestEnv(extraConf);
     const component = helpers.createComponent(test);
     const jobs = 3;
-    const buildResult = blacksmithHandler.exec(`--log-level trace --log-file ${path.join(test.buildDir, 'test.log')} ` +
+    const buildResult = blacksmithHandler.exec(
+      `--log-level trace --log-file ${path.join(test.buildDir, 'test.log')} ` +
       `--config ${test.configFile} ` +
       'containerized-build ' +
       `--json ${component.buildSpecFile} ` +
@@ -100,7 +102,7 @@ describe('#containerized-build()', function() {
     )));
     expect(summary).to.include.keys(['prefix', 'platform', 'artifacts', 'tarball', 'sha256']);
     // Modifies the log level
-    expect(buildResult.stdout).to.contain('blacksm TRACE ENVIRONMENT VARIABLES');
+    expect(buildResult.stdout).to.match(/blacksm.*TRACE.*ENVIRONMENT VARIABLES/);
     // Set the log file
     expect(path.join(test.buildDir, 'test.log')).to.be.file();
     // Modifies the build directory - T12761
@@ -120,7 +122,8 @@ describe('#containerized-build()', function() {
     const component2 = helpers.createComponent(test, {
       id: 'sample2',
     });
-    blacksmithHandler.exec(`--config ${test.configFile} ` +
+    blacksmithHandler.javascriptExec(path.join(__dirname, '../index.js'),
+      `--config ${test.configFile} ` +
       `containerized-build --build-dir ${test.buildDir} ` +
       `${component.id}:${test.assetsDir}/${component.id}-${component.version}.tar.gz`);
     const continueBuildRes = blacksmithHandler.exec('--log-level trace ' +
@@ -140,7 +143,7 @@ describe('#containerized-build()', function() {
   it('Can open a shell and list component content', function() {
     const test = helpers.createTestEnv(extraConf);
     const component = helpers.createComponent(test);
-    blacksmithHandler.exec(
+    blacksmithHandler.javascriptExec(path.join(__dirname, '../index.js'),
       `--config ${test.configFile} containerized-build --build-dir ${test.buildDir} ` +
       `--json ${component.buildSpecFile} ` +
       `${component.id}:${test.assetsDir}/${component.id}-${component.version}.tar.gz`);

--- a/test/inspect.js
+++ b/test/inspect.js
@@ -37,14 +37,14 @@ describe('#inspect()', function() {
   }
 
   it('Inspect component properties to stdout', function() {
-    const res = blacksmithHandler.exec(
+    const res = blacksmithHandler.javascriptExec(path.join(__dirname, '../index.js'),
       `--config ${test.configFile} inspect --json ${component1.buildSpecFile} ` +
       `${component2.id}:${test.assetsDir}/${component2.id}-${component2.version}.tar.gz`
     );
     check(res.stdout);
   });
   it('Inspect component properties to file', function() {
-    blacksmithHandler.exec(
+    blacksmithHandler.javascriptExec(path.join(__dirname, '../index.js'),
       `--config ${test.configFile} inspect ` +
       `--output-file ${path.join(test.buildDir, 'spec.json')} ` +
       `--json ${component1.buildSpecFile} ` +


### PR DESCRIPTION
Call javascriptExec instead of exec in tests that doesn't spawnn a process.
It increases the 'Statements' coverage from 75.82% to 91.61%