### PR TITLE
Explicit error when an invalid value is set as a file path

### DIFF
--- a/lib/base-components/component.js
+++ b/lib/base-components/component.js
@@ -113,6 +113,7 @@ class Component {
     if (this.extraFiles.length > 0) {
       nfile.mkdir(this.extraFilesDir);
       _.each(this.extraFiles, f => {
+        if (_.isEmpty(f)) throw new Error(`Wrong extraFiles defintion. Found ${f} instead of a file path`);
         if (!path.isAbsolute(f)) throw new Error(`Path to extraFiles should be absolute. Found ${f}`);
         nfile.copy(f, this.extraFilesDir);
       });
@@ -136,6 +137,7 @@ class Component {
    */
   patch() {
     _.each(this.patches, p => {
+      if (_.isEmpty(p)) throw new Error(`Wrong patches defintion. Found ${p} instead of a file path`);
       if (!path.isAbsolute(p)) throw new Error(`Path to patches should be absolute. Found ${p}`);
       this.logger.trace(`Applying patch ${p}`);
       cutils.patch(this.srcDir, p, this._getCmdOpts({patchLevel: this.patchLevel || 0}));
@@ -179,6 +181,9 @@ class Component {
    * @function BaseComponents.Component~extract
    */
   extract() {
+    if (_.isEmpty(this.sourceTarball)) {
+      throw new Error(`The source tarball is missing. Received ${this.sourceTarball}`);
+    }
     if (!path.isAbsolute(this.sourceTarball)) {
       throw new Error(`Path to sourceTarball should be absolute. Found ${this.sourceTarball}`);
     }

--- a/test/base-components/component.js
+++ b/test/base-components/component.js
@@ -227,6 +227,14 @@ describe('Component', () => {
       component.setup({be: {prefixDir: testEnv.prefix, sandboxDir: testEnv.sandbox}}, null);
     });
 
+    it('"copyExtraFiles" should throw an error if the path is not valid', () => {
+      component.extraFiles = [null];
+      fs.mkdirSync(path.join(testEnv.sandbox, 'sample-1.0.0'));
+      expect(() => component.copyExtraFiles()).to.throw(
+        'Wrong extraFiles defintion. Found null instead of a file path'
+      );
+    });
+
     it('"copyExtraFiles" should throw an error if the path is not absolute', () => {
       component.extraFiles = ['test'];
       fs.mkdirSync(path.join(testEnv.sandbox, 'sample-1.0.0'));
@@ -263,6 +271,11 @@ describe('Component', () => {
       component.setup({be: {prefixDir: testEnv.prefix, sandboxDir: testEnv.sandbox}}, null);
     });
 
+    it('"extract" should throw an error if the path is not set', () => {
+      component.sourceTarball = null;
+      expect(() => component.extract()).to.throw('The source tarball is missing. Received null');
+    });
+
     it('"extract" should throw an error if the path is not absolute', () => {
       component.sourceTarball = 'tarball.tar.gz';
       expect(() => component.extract()).to.throw('Path to sourceTarball should be absolute. Found tarball.tar.gz');
@@ -290,6 +303,11 @@ describe('Component', () => {
 
     afterEach('clean environment', () => {
       helpers.cleanTestEnv();
+    });
+
+    it('"patch" method should throw an error if the path is not valid', () => {
+      component.patches = [null];
+      expect(() => component.patch()).to.throw('Wrong patches defintion. Found null instead of a file path');
     });
 
     it('"patch" method should throw an error if the path is not absolute', () => {


### PR DESCRIPTION
Previously if no file path was defined it threw an error:
```
blacksm ERROR [docker] blacksm ERROR Path must be a string. Received null
blacksm ERROR The process failed: StatusCode=1
```
That gave no information about which path was wrong