### PR TITLE
Recursive search for excluded files

### DIFF
--- a/lib/core/build-manager/artifacts/summary.js
+++ b/lib/core/build-manager/artifacts/summary.js
@@ -5,6 +5,7 @@ const strftime = require('strftime');
 const ncrypt = require('nami-utils').crypt;
 const nfile = require('nami-utils').file;
 const tarballUtils = require('tarball-utils');
+const path = require('path');
 const Artifact = require('./artifact');
 const FsTracker = require('./fstracker');
 
@@ -103,9 +104,14 @@ class Summary {
    */
   compressArtifacts(file) {
     const pickedFiles = _.last(this.artifacts).pick || [];
-    const excludedFiles = _.compact(_.flatten(_.map(this.artifacts, artifact => {
-      if (artifact.exclude) return _.map(artifact.exclude, f => nfile.join(artifact.prefix, f));
-    })));
+    const excludedFiles = [];
+    _.each(this.artifacts, artifact => {
+      if (artifact.exclude) {
+        _.each(artifact.exclude, f => {
+          excludedFiles.push(nfile.join(artifact.prefix, f), nfile.join(artifact.prefix, '**', f));
+        });
+      }
+    });
     if (this._fsTracker) {
       const res = this._fsTracker.captureDelta(file, {
         all: true,

--- a/lib/core/build-manager/artifacts/summary.js
+++ b/lib/core/build-manager/artifacts/summary.js
@@ -5,7 +5,6 @@ const strftime = require('strftime');
 const ncrypt = require('nami-utils').crypt;
 const nfile = require('nami-utils').file;
 const tarballUtils = require('tarball-utils');
-const path = require('path');
 const Artifact = require('./artifact');
 const FsTracker = require('./fstracker');
 


### PR DESCRIPTION
Previously the exlude paths were just applied to the root of the component prefix.
This differ from the `exclude` option of `tar` that excludes the file even if it is in a deeper directory.

Note that we need to exclude files per prefix in just one `tar` call so we still need to use absolute paths when excluding.