### PR TITLE
Improve _reduceByDirectory logic

### DIFF
--- a/lib/core/build-manager/artifacts/fstracker.js
+++ b/lib/core/build-manager/artifacts/fstracker.js
@@ -111,25 +111,37 @@ class FileSystemTracker {
     options = _.defaults(options, {}, {
       unless: []
     });
+    // We order the list so the larger paths are evaluated first
+    const workingList = _.orderBy(list, f => f.split('/').length, 'desc');
     const result = [];
-    _.each(list, f => {
-      if (nfile.isFile(f)) {
-        const dir = nfile.dirname(f);
-        if (result.indexOf(dir) < 0) {
-          // If all the files included in the directory are in the list we can just return the directory
-          const allFilesAreIncluded = _.every(nfile.glob(nfile.join(dir, '*')), ff => {
-            return list.indexOf(ff) >= 0;
+    _.each(workingList, f => {
+      if (_.some(result, r => _.startsWith(f, r))) {
+        // The file is already include since some of its parent folder is in the resulting list
+      } else {
+        let allFilesAreIncluded = true;
+        let target = f;
+        let dir = nfile.dirname(f);
+        while (allFilesAreIncluded && dir !== this._directory) {
+          // If all the files/folders of the parent directory we can just specify the parent folder
+          allFilesAreIncluded = _.every(nfile.glob(nfile.join(dir, '*')), ff => {
+            return workingList.indexOf(ff) >= 0;
           });
-          // Unless the directory is explicity discarded
-          const dirShouldBeAvoided = _.find(options.unless, d => d === dir);
-          if (allFilesAreIncluded && !dirShouldBeAvoided) {
-            result.push(dir);
-          } else {
-            result.push(f);
+          if (allFilesAreIncluded) {
+            // We include the dir in the working list
+            // since it only contained files
+            if (workingList.indexOf(dir) === -1) workingList.push(dir);
+            target = dir;
+          }
+          // Try again with the parent folder
+          dir = nfile.dirname(dir);
+        }
+        if (result.indexOf(target) < 0) {
+          // Unless the path is explicity discarded
+          const shouldBeAvoided = _.find(options.unless, d => d === target);
+          if (!shouldBeAvoided) {
+            result.push(target);
           }
         }
-      } else {
-        result.push(f);
       }
     });
     return result;

--- a/lib/core/build-manager/artifacts/fstracker.js
+++ b/lib/core/build-manager/artifacts/fstracker.js
@@ -116,7 +116,7 @@ class FileSystemTracker {
     const result = [];
     _.each(workingList, f => {
       if (_.some(result, r => _.startsWith(f, r))) {
-        // The file is already include since some of its parent folder is in the resulting list
+        // The file is already included since some of its parent folder is in the resulting list
       } else {
         let allFilesAreIncluded = true;
         let target = f;
@@ -135,7 +135,7 @@ class FileSystemTracker {
           // Try again with the parent folder
           dir = nfile.dirname(dir);
         }
-        if (result.indexOf(target) < 0) {
+        if (!_.includes(result, target)) {
           // Unless the path is explicity discarded
           const shouldBeAvoided = _.find(options.unless, d => d === target);
           if (!shouldBeAvoided) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {

--- a/test/core/fstracker.js
+++ b/test/core/fstracker.js
@@ -96,6 +96,27 @@ describe('FSTracker', () => {
     tarballUtils.tar.restore();
     expect(result).to.be.eql([path.join(testDir, 'directory')]);
   });
+  it('calls for compression using just the minimum number of directories', () => {
+    const fstracker = new FileSystemTracker(testDir);
+    fstracker.init();
+    fs.writeFileSync(path.join(testDir, 'a'), 'hello');
+    fs.mkdirSync(path.join(testDir, 'b'));
+    fs.writeFileSync(path.join(testDir, 'b/c'), 'hello');
+    fs.mkdirSync(path.join(testDir, 'b/d'));
+    fs.writeFileSync(path.join(testDir, 'b/d/e'), 'hello');
+    fstracker.commit();
+    const tarball = '/tmp/blacksmith-test-env/delta.tar.gz';
+    let result = [];
+    sinon.stub(tarballUtils, 'tar').callsFake(list => result = list);
+    try {
+      fstracker.captureDelta(tarball, {all: true});
+    } catch (e) {
+      tarballUtils.tar.restore();
+      throw e;
+    }
+    tarballUtils.tar.restore();
+    expect(result).to.be.eql([path.join(testDir, 'b'), path.join(testDir, 'a')]);
+  });
   it('captures a selection of files', () => {
     const fstracker = new FileSystemTracker(testDir);
     fstracker.init();


### PR DESCRIPTION
The previous implementation of _reduceByDirectory only reduced the given list
specifying all the directories instead of all the files. With this improvement
we also reduce the amount of directories of the result if all the content is 
included in the list.