### PR TITLE
Fix reduceByDirectory

### DIFF
--- a/lib/core/build-manager/artifacts/fstracker.js
+++ b/lib/core/build-manager/artifacts/fstracker.js
@@ -115,13 +115,21 @@ class FileSystemTracker {
     const workingList = _.orderBy(list, f => f.split('/').length, 'desc');
     const result = [];
     _.each(workingList, f => {
-      if (_.some(result, r => _.startsWith(f, r))) {
+      const isContained = (dir, file) => {
+        let res = false;
+        // If nfile.relativize returns a relative path the file is inside the directory
+        if (nfile.isDirectory(dir) && nfile.relativize(file, dir) !== file) {
+          res = true;
+        }
+        return res;
+      };
+      if (_.some(result, r => isContained(r, f))) {
         // The file is already included since some of its parent folder is in the resulting list
       } else {
         let allFilesAreIncluded = true;
         let target = f;
         let dir = nfile.dirname(f);
-        while (allFilesAreIncluded && dir !== this._directory) {
+        while (allFilesAreIncluded) {
           // If all the files/folders of the parent directory we can just specify the parent folder
           allFilesAreIncluded = _.every(nfile.glob(nfile.join(dir, '*')), ff => {
             return workingList.indexOf(ff) >= 0;

--- a/test/core/fstracker.js
+++ b/test/core/fstracker.js
@@ -117,6 +117,26 @@ describe('FSTracker', () => {
     tarballUtils.tar.restore();
     expect(result).to.be.eql([path.join(testDir, 'b'), path.join(testDir, 'a')]);
   });
+  it('calls for compression using just the minimum number of directories without missing files', () => {
+    const fstracker = new FileSystemTracker(testDir);
+    fstracker.init();
+    fs.writeFileSync(path.join(testDir, 'a'), 'hello');
+    fs.mkdirSync(path.join(testDir, 'b'));
+    fs.writeFileSync(path.join(testDir, 'b/c'), 'hello');
+    fs.writeFileSync(path.join(testDir, 'bb'), 'hello');
+    fstracker.commit();
+    const tarball = '/tmp/blacksmith-test-env/delta.tar.gz';
+    let result = [];
+    sinon.stub(tarballUtils, 'tar').callsFake(list => result = list);
+    try {
+      fstracker.captureDelta(tarball, {all: true});
+    } catch (e) {
+      tarballUtils.tar.restore();
+      throw e;
+    }
+    tarballUtils.tar.restore();
+    expect(result).to.be.eql([path.join(testDir, 'b'), path.join(testDir, 'a'), path.join(testDir, 'bb')]);
+  });
   it('captures a selection of files', () => {
     const fstracker = new FileSystemTracker(testDir);
     fstracker.init();


### PR DESCRIPTION
The previous implementation ignores files with a similar pattern than the directories included in the result.