### PR TITLE
Use tar library instead tarballUtils when compressing artifacts

### DIFF
--- a/lib/core/build-manager/artifacts/fstracker.js
+++ b/lib/core/build-manager/artifacts/fstracker.js
@@ -150,7 +150,9 @@ class FileSystemTracker {
     const filesToCapture = this.constructor.filterFiles(list, {
       paths: options.pathsToInclude,
       pick: options.pick,
-      exclude: _.map(options.exclude, excludePattern => path.isAbsolute(excludePattern) ? excludePattern : nfile.join(this._directory, excludePattern))
+      exclude: _.map(options.exclude, excludePattern => {
+        return path.isAbsolute(excludePattern) ? excludePattern : nfile.join(this._directory, excludePattern);
+      })
     }, {relativize: this._directory});
     if (_.isEmpty(filesToCapture)) return null;
     tar.c({

--- a/lib/core/build-manager/artifacts/fstracker.js
+++ b/lib/core/build-manager/artifacts/fstracker.js
@@ -3,7 +3,8 @@
 const _ = require('lodash');
 const nos = require('nami-utils').os;
 const nfile = require('nami-utils').file;
-const tarballUtils = require('tarball-utils');
+const path = require('path');
+const tar = require('tar');
 
 /**
  * Class representing the File System Tracking that allows to capture the differentail between build steps
@@ -44,10 +45,19 @@ class FileSystemTracker {
   }
 
   _populateEmptyDirs() {
+    const populatedDirs = [];
     nfile.walkDir(this._directory, function(f) {
       if (nfile.isDirectory(f) && nfile.isEmptyDir(f)) {
         nfile.write(nfile.join(f, '.__empty_dir'));
+        populatedDirs.push(f);
       }
+    });
+    return populatedDirs;
+  }
+
+  static _cleanPopulatedDirs(dirs) {
+    _.each(dirs, d => {
+      nfile.delete(nfile.join(d, '.__empty_dir'));
     });
   }
 
@@ -57,8 +67,17 @@ class FileSystemTracker {
    * @returns {Array} - List of files
    */
   diff() {
-    this._populateEmptyDirs();
-    let list = nos.runProgram('git', ['ls-files', '--modified', '--others', '.'], {cwd: this._directory}).split('\n');
+    // Git does not recognize empty folders as changes so we need to populate them to be tracked
+    const populatedDirs = this._populateEmptyDirs();
+    let list = _.map(
+      nos.runProgram('git', ['ls-files', '--modified', '--others', '.'], {cwd: this._directory}).split('\n'), f => {
+        if (nfile.basename(f) === '.__empty_dir') {
+          return nfile.dirname(f);
+        } else {
+          return f;
+        }
+      });
+    this.constructor._cleanPopulatedDirs(populatedDirs);
     // Remove deleted files
     const deleted = nos.runProgram('git', ['ls-files', '--deleted', '.'], {cwd: this._directory}).split('\n');
     list = _.difference(list, deleted);
@@ -77,8 +96,13 @@ class FileSystemTracker {
    * If set the rest of parameters will be ignored
    * @param {Array} [conditions.exclude] - File patterns to exclude files from the list. Any by default.
    * @param {Array} [conditions.paths] - Root paths that files should be contained into. All by default.
+   * @param {Object} [options]
+   * @param {string} [options.relativize] - Path to relativize the result list.
    */
-  static filterFiles(list, conditions) {
+  static filterFiles(list, conditions, options) {
+    options = _.defaults({}, options, {
+      relativize: null
+    });
     conditions = _.defaults({}, conditions, {
       pick: [],
       exclude: [],
@@ -99,51 +123,14 @@ class FileSystemTracker {
           match = _.some(_.flatten([conditions.paths]), p => _.startsWith(f, p));
         }
         if (match && nfile.exists(f)) {
-          result.push(f);
+          if (!_.isEmpty(options.relativize)) {
+            result.push(nfile.relativize(f, options.relativize));
+          } else {
+            result.push(f);
+          }
         }
       });
     }
-    return result;
-  }
-
-  // Avoid to use as a list with every single file if the whole directory is included
-  _reduceByDirectory(list, options) {
-    options = _.defaults(options, {}, {
-      unless: []
-    });
-    // We order the list so the larger paths are evaluated first
-    const workingList = _.orderBy(list, f => f.split('/').length, 'desc');
-    const result = [];
-    _.each(workingList, f => {
-      if (_.some(result, r => _.startsWith(f, r))) {
-        // The file is already included since some of its parent folder is in the resulting list
-      } else {
-        let allFilesAreIncluded = true;
-        let target = f;
-        let dir = nfile.dirname(f);
-        while (allFilesAreIncluded && dir !== this._directory) {
-          // If all the files/folders of the parent directory we can just specify the parent folder
-          allFilesAreIncluded = _.every(nfile.glob(nfile.join(dir, '*')), ff => {
-            return workingList.indexOf(ff) >= 0;
-          });
-          if (allFilesAreIncluded) {
-            // We include the dir in the working list
-            // since it only contained files
-            if (workingList.indexOf(dir) === -1) workingList.push(dir);
-            target = dir;
-          }
-          // Try again with the parent folder
-          dir = nfile.dirname(dir);
-        }
-        if (!_.includes(result, target)) {
-          // Unless the path is explicity discarded
-          const shouldBeAvoided = _.find(options.unless, d => d === target);
-          if (!shouldBeAvoided) {
-            result.push(target);
-          }
-        }
-      }
-    });
     return result;
   }
 
@@ -163,11 +150,15 @@ class FileSystemTracker {
     const filesToCapture = this.constructor.filterFiles(list, {
       paths: options.pathsToInclude,
       pick: options.pick,
-    });
+      exclude: _.map(options.exclude, excludePattern => path.isAbsolute(excludePattern) ? excludePattern : nfile.join(this._directory, excludePattern))
+    }, {relativize: this._directory});
     if (_.isEmpty(filesToCapture)) return null;
-    // If the file list to compress is too big we reach the Node maximum size
-    const reducedList = this._reduceByDirectory(filesToCapture, {unless: this._directory});
-    tarballUtils.tar(reducedList, file, {cwd: this._directory, exclude: options.exclude});
+    tar.c({
+      sync: true,
+      gzip: true,
+      file: file,
+      cwd: this._directory
+    }, filesToCapture);
     return file;
   }
 

--- a/lib/core/build-manager/artifacts/fstracker.js
+++ b/lib/core/build-manager/artifacts/fstracker.js
@@ -44,9 +44,9 @@ class FileSystemTracker {
     nos.runProgram('git', ['add', '.'], {cwd: this._directory});
   }
 
-  _populateEmptyDirs() {
+  _populateEmptyDirs(dir) {
     const populatedDirs = [];
-    nfile.walkDir(this._directory, function(f) {
+    nfile.walkDir(dir, function(f) {
       if (nfile.isDirectory(f) && nfile.isEmptyDir(f)) {
         nfile.write(nfile.join(f, '.__empty_dir'));
         populatedDirs.push(f);
@@ -55,7 +55,7 @@ class FileSystemTracker {
     return populatedDirs;
   }
 
-  static _cleanPopulatedDirs(dirs) {
+  _cleanPopulatedDirs(dirs) {
     _.each(dirs, d => {
       nfile.delete(nfile.join(d, '.__empty_dir'));
     });
@@ -68,7 +68,7 @@ class FileSystemTracker {
    */
   diff() {
     // Git does not recognize empty folders as changes so we need to populate them to be tracked
-    const populatedDirs = this._populateEmptyDirs();
+    const populatedDirs = this._populateEmptyDirs(this._directory);
     let list = _.map(
       nos.runProgram('git', ['ls-files', '--modified', '--others', '.'], {cwd: this._directory}).split('\n'), f => {
         if (nfile.basename(f) === '.__empty_dir') {
@@ -77,7 +77,7 @@ class FileSystemTracker {
           return f;
         }
       });
-    this.constructor._cleanPopulatedDirs(populatedDirs);
+    this._cleanPopulatedDirs(populatedDirs);
     // Remove deleted files
     const deleted = nos.runProgram('git', ['ls-files', '--deleted', '.'], {cwd: this._directory}).split('\n');
     list = _.difference(list, deleted);
@@ -155,6 +155,8 @@ class FileSystemTracker {
       })
     }, {relativize: this._directory});
     if (_.isEmpty(filesToCapture)) return null;
+    // We are not using tarballUtils.tar for compressing
+    // since it has a limitation about the number of files to use as arguments
     tar.c({
       sync: true,
       gzip: true,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "nami-logger": "^0.0.1",
     "nami-utils": "^0.2.0",
     "strftime": "^0.9.2",
+    "tar": "^3.1.5",
     "tarball-utils": "bitnami/node-tarball-utils#v3.0.2",
     "version-utils": "bitnami/node-version-utils#v2.0.1"
   },

--- a/test/core/fstracker.js
+++ b/test/core/fstracker.js
@@ -77,46 +77,6 @@ describe('FSTracker', () => {
     fstracker.captureDelta(tarball, {all: true});
     expect(spawnSync('tar', ['-ztf', tarball]).stdout.toString()).to.contain('hello_dir');
   });
-  it('calls for compression using just the directory paths', () => {
-    const fstracker = new FileSystemTracker(testDir);
-    fstracker.init();
-    fs.mkdirSync(path.join(testDir, 'directory'));
-    fs.writeFileSync(path.join(testDir, 'directory/hello'), 'hello');
-    fs.writeFileSync(path.join(testDir, 'directory/hello2'), 'hello');
-    fstracker.commit();
-    const tarball = '/tmp/blacksmith-test-env/delta.tar.gz';
-    let result = [];
-    sinon.stub(tarballUtils, 'tar').callsFake(list => result = list);
-    try {
-      fstracker.captureDelta(tarball, {all: true});
-    } catch (e) {
-      tarballUtils.tar.restore();
-      throw e;
-    }
-    tarballUtils.tar.restore();
-    expect(result).to.be.eql([path.join(testDir, 'directory')]);
-  });
-  it('calls for compression using just the minimum number of directories', () => {
-    const fstracker = new FileSystemTracker(testDir);
-    fstracker.init();
-    fs.writeFileSync(path.join(testDir, 'a'), 'hello');
-    fs.mkdirSync(path.join(testDir, 'b'));
-    fs.writeFileSync(path.join(testDir, 'b/c'), 'hello');
-    fs.mkdirSync(path.join(testDir, 'b/d'));
-    fs.writeFileSync(path.join(testDir, 'b/d/e'), 'hello');
-    fstracker.commit();
-    const tarball = '/tmp/blacksmith-test-env/delta.tar.gz';
-    let result = [];
-    sinon.stub(tarballUtils, 'tar').callsFake(list => result = list);
-    try {
-      fstracker.captureDelta(tarball, {all: true});
-    } catch (e) {
-      tarballUtils.tar.restore();
-      throw e;
-    }
-    tarballUtils.tar.restore();
-    expect(result).to.be.eql([path.join(testDir, 'b'), path.join(testDir, 'a')]);
-  });
   it('captures a selection of files', () => {
     const fstracker = new FileSystemTracker(testDir);
     fstracker.init();


### PR DESCRIPTION
The problem with the tar method of tarball utils is that if the list of files to compress is too big it throws an error.
We reduced the amount of files passed to tarballUtils.tar but that slowed down the process a lot.

Instead of that we are now using the 'tar' library for node since it allowes any amount of files as arguments. To adapt
the code to 'tar' we needed: 
 - Use relative paths when calling for compression
 - Exclude the files beforehand. `tar.c` doesn't support to exclude files.