### PR TITLE
add support for x64 archs

### DIFF
--- a/lib/distro/distro.js
+++ b/lib/distro/distro.js
@@ -87,7 +87,7 @@ class Distro {
     return _.filter(files, file => {
       if (!nfile.isLink(file) && nfile.isBinary(file)) {
         const fileInfo = this._getBinaryInfo(infoCommand, file);
-        const extendedArch = this._arch === 'x64' ? /(64-bit|elf64)/ : /(32-bit|elf32)/;
+        const extendedArch = ['x64', 'amd64', 'x86_64'].includes(this._arch) ? /(64-bit|elf64)/ : /(32-bit|elf32)/;
         return fileInfo.match(/(dynamically linked|EXEC_P)/) && fileInfo.match(extendedArch);
       } else {
         return false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {

--- a/test/distro/debian.js
+++ b/test/distro/debian.js
@@ -54,17 +54,19 @@ describe('Debian', () => {
       .to.be.eql('apt-get install -y --no-install-recommends zlib openssl');
   });
   describe('returns a list of system packages given a list of files', () => {
-    it('using "file"', () => {
-      nos.isInPath.restore();
-      sinon.stub(nos, 'isInPath').callsFake(cmd => cmd === 'file');
-      const debian = new Debian('x64');
-      expect(debian.getRuntimePackages([path.join(__dirname, 'binary_sample')])).to.be.eql(['libc6']);
-    });
-    it('using "objdump"', () => {
-      nos.isInPath.restore();
-      sinon.stub(nos, 'isInPath').callsFake(cmd => cmd === 'objdump');
-      const debian = new Debian('x64');
-      expect(debian.getRuntimePackages([path.join(__dirname, 'binary_sample')])).to.be.eql(['libc6']);
+    ['x64', 'amd64'].forEach(arch => {
+        it(`[${arch}] using "file"`, () => {
+          nos.isInPath.restore();
+          sinon.stub(nos, 'isInPath').callsFake(cmd => cmd === 'file');
+          const debian = new Debian(arch);
+          expect(debian.getRuntimePackages([path.join(__dirname, 'binary_sample')])).to.be.eql(['libc6']);
+        });
+        it(`[${arch}] using "objdump"`, () => {
+          nos.isInPath.restore();
+          sinon.stub(nos, 'isInPath').callsFake(cmd => cmd === 'objdump');
+          const debian = new Debian(arch);
+          expect(debian.getRuntimePackages([path.join(__dirname, 'binary_sample')])).to.be.eql(['libc6']);
+        });
     });
   });
   it('returns a list of system packages installed', () => {

--- a/test/distro/index.js
+++ b/test/distro/index.js
@@ -8,6 +8,7 @@ describe('Distro', () => {
   describe('Factory', () => {
     it('obtains a distribution', () => {
       expect(() => distroFactory.getDistro('debian', 'x64')).to.not.throw();
+      expect(() => distroFactory.getDistro('debian', 'amd64')).to.not.throw();
       expect(() => distroFactory.getDistro('centos', 'x86')).to.not.throw();
     });
     it('throws an error for an unknown distro', () => {


### PR DESCRIPTION
Some Linux distributions use a different arch for x64 systems. This adds support for some of them.