### PR TITLE
Fix requirements filtering

### DIFF
--- a/lib/containerized-builder/image-provider/index.js
+++ b/lib/containerized-builder/image-provider/index.js
@@ -57,7 +57,7 @@ class ImageProvider {
   }
 
   _filterRequirements(list, platform) {
-    const platformRequirements = _.filter(list, req => req.type !== 'system' || req.distro === platform.distro);
+    const platformRequirements = _.filter(list, req => !req.distro || req.distro === platform.distro);
     return _.uniqBy(platformRequirements, 'id');
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {

--- a/test/containerized-builder/image-provider/image-provider.js
+++ b/test/containerized-builder/image-provider/image-provider.js
@@ -123,12 +123,14 @@ describe('ImageProvider', () => {
       {id: 'glibc', type: 'system', distro: 'centos'},
       {id: 'install_pip', type: 'pip', installCommands: 'pip install wheel'},
       {id: 'install_pip_centos', type: 'pip', distro: 'centos', installCommands: 'pip install numpy'},
+      {id: 'install_pip_debian', type: 'pip', distro: 'debian', installCommands: 'pip install Cython'},
     ], platform);
     expect(
       _.find(imageProvider.imageRegistry.images, {id: imageID}).buildTools
     ).to.be.eql([
       {id: 'zlib', type: 'system', distro: 'debian'},
       {id: 'install_pip', type: 'pip', installCommands: 'pip install wheel'},
+      {id: 'install_pip_debian', type: 'pip', distro: 'debian', installCommands: 'pip install Cython'},
     ]);
   });  
 });

--- a/test/containerized-builder/image-provider/image-provider.js
+++ b/test/containerized-builder/image-provider/image-provider.js
@@ -120,10 +120,15 @@ describe('ImageProvider', () => {
     });
     const imageID = imageProvider.getImage([
       {id: 'zlib', type: 'system', distro: 'debian'},
-      {id: 'glibc', type: 'system', distro: 'centos'}
+      {id: 'glibc', type: 'system', distro: 'centos'},
+      {id: 'install_pip', type: 'pip', installCommands: 'pip install wheel'},
+      {id: 'install_pip_centos', type: 'pip', distro: 'centos', installCommands: 'pip install numpy'},
     ], platform);
     expect(
       _.find(imageProvider.imageRegistry.images, {id: imageID}).buildTools
-    ).to.be.eql([{id: 'zlib', type: 'system', distro: 'debian'}]);
-  });
+    ).to.be.eql([
+      {id: 'zlib', type: 'system', distro: 'debian'},
+      {id: 'install_pip', type: 'pip', installCommands: 'pip install wheel'},
+    ]);
+  });  
 });


### PR DESCRIPTION
Currently, it is not possible to specify dependencies like the following:

```
{
        type: 'backport-package',
        distro: 'debian',
        id: 'openjdk-8-jdk-headless',
        installCommands: [
          'echo \'deb http://httpredir.debian.org/debian jessie-backports main\' >'
            + ' /etc/apt/sources.list.d/backports.list',
          'install_packages -t jessie-backports openjdk-8-jdk-headless',
        ],
      }
```

Even though it specifies debian as the distro, it will be executed for every distro. This PR fixes it