### PR TITLE
Check folders when extracting runtimeDependencies

### DIFF
--- a/lib/core/build-manager/artifacts/fstracker.js
+++ b/lib/core/build-manager/artifacts/fstracker.js
@@ -112,6 +112,7 @@ class FileSystemTracker {
     if (!_.isEmpty(conditions.pick)) {
       result = _.filter(_.flatten([conditions.pick]), f => nfile.exists(f));
       if (options.relativize) result = _.map(result, f => nfile.relativize(f, options.relativize));
+      result = _.flatten(_.map(result, file => (nfile.isDirectory(file) ? nfile.glob(nfile.join(file, '**')) : file)));
     } else {
       let filesToExclude = [];
       if (conditions.exclude) {
@@ -132,7 +133,6 @@ class FileSystemTracker {
         }
       });
     }
-    result = _.flatten(_.map(result, file => (nfile.isDirectory(file) ? nfile.glob(nfile.join(file, '**')) : file)));
 
     return _.uniq(result);
   }

--- a/lib/core/build-manager/artifacts/fstracker.js
+++ b/lib/core/build-manager/artifacts/fstracker.js
@@ -132,6 +132,8 @@ class FileSystemTracker {
         }
       });
     }
+    result = _.uniq(_.flatten(_.map(result, file => (nfile.isDirectory(file) ? nfile.glob(nfile.join(file, '**')) : file))));
+
     return result;
   }
 

--- a/lib/core/build-manager/artifacts/fstracker.js
+++ b/lib/core/build-manager/artifacts/fstracker.js
@@ -133,7 +133,6 @@ class FileSystemTracker {
         }
       });
     }
-
     return _.uniq(result);
   }
 

--- a/lib/core/build-manager/artifacts/fstracker.js
+++ b/lib/core/build-manager/artifacts/fstracker.js
@@ -132,9 +132,9 @@ class FileSystemTracker {
         }
       });
     }
-    result = _.uniq(_.flatten(_.map(result, file => (nfile.isDirectory(file) ? nfile.glob(nfile.join(file, '**')) : file))));
+    result = _.flatten(_.map(result, file => (nfile.isDirectory(file) ? nfile.glob(nfile.join(file, '**')) : file)));
 
-    return result;
+    return _.uniq(result);
   }
 
   /**

--- a/lib/distro/distro.js
+++ b/lib/distro/distro.js
@@ -137,7 +137,8 @@ class Distro {
     });
     let runtimePackages = [];
     this.logger.trace('Getting files to evaluate');
-    const binaries = this._getBinaries(files);
+    const fileList = _.flatten(_.map(files, file => (nfile.isDirectory(file) ? nfile.glob(nfile.join(file, '**')) : file)));
+    const binaries = this._getBinaries(fileList);
     if (!_.isEmpty(binaries)) {
       this.logger.debug('Getting information about linked libraries');
       const linksInfo = nos.runProgram('ldd', binaries, {

--- a/lib/distro/distro.js
+++ b/lib/distro/distro.js
@@ -137,8 +137,7 @@ class Distro {
     });
     let runtimePackages = [];
     this.logger.trace('Getting files to evaluate');
-    const fileList = _.flatten(_.map(files, file => (nfile.isDirectory(file) ? nfile.glob(nfile.join(file, '**')) : file)));
-    const binaries = this._getBinaries(fileList);
+    const binaries = this._getBinaries(files);
     if (!_.isEmpty(binaries)) {
       this.logger.debug('Getting information about linked libraries');
       const linksInfo = nos.runProgram('ldd', binaries, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
This allows the following case to fully extract dependencies:

```
  initialize() {
    this.pick = [
      $file.join(this.prefix, 'lib'),
      $file.join(this.prefix, 'licenses'),
      $file.join(this.prefix, 'bin/psql'),
      $file.join(this.prefix, 'bin/pg_dump'),
      $file.join(this.prefix, 'bin/pg_restore'),
    ];
  }
```

Currently, blacksmith would not search inside directories for binaries. With this PR, it works.