### PR TITLE
Update blacksmith-extra-component-types for Ruby 2.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "blacksmith",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {
     "node": "~6"
   },
   "dependencies": {
-    "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.29",
+    "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.30",
     "cmd-parser": "^0.0.1",
     "common-utils": "bitnami/node-common-utils#v2.2.0",
     "compilation-utils": "bitnami/node-compilation-utils#v1.0.4",


### PR DESCRIPTION
We updated the latest release version of Ruby 2.4.