### PR TITLE
Add amazon and ubuntu platforms

### DIFF
--- a/lib/distro/distro.js
+++ b/lib/distro/distro.js
@@ -102,10 +102,10 @@ class Distro {
     _.each(entries, line => {
       // The lines including a library has the following format: ' => /path/to/library.so'
       if (line.match(' => /')) {
-        const lib = line.match(/ => ([^\s]*)/)[1];
-        /* eslint-disable no-unused-expressions */
-        nfile.isLink(lib) ? result.push(fs.realpathSync(lib)) : result.push(lib);
-        /* eslint-enable no-unused-expressions */
+        let lib = line.match(/ => ([^\s]*)/)[1];
+	// If the library is a symlink, we use the realpath
+        lib = nfile.isLink(lib) ? fs.realpathSync(lib) : lib;
+        result.push(lib);
       }
     });
     return _.uniq(result);

--- a/lib/distro/distro.js
+++ b/lib/distro/distro.js
@@ -103,7 +103,7 @@ class Distro {
       // The lines including a library has the following format: ' => /path/to/library.so'
       if (line.match(' => /')) {
         let lib = line.match(/ => ([^\s]*)/)[1];
-	// If the library is a symlink, we use the realpath
+        // If the library is a symlink, we use the realpath
         lib = nfile.isLink(lib) ? fs.realpathSync(lib) : lib;
         result.push(lib);
       }

--- a/lib/distro/distro.js
+++ b/lib/distro/distro.js
@@ -4,6 +4,7 @@ const _ = require('nami-utils/lodash-extra');
 const nfile = require('nami-utils').file;
 const nos = require('nami-utils').os;
 const Logger = require('nami-logger');
+const fs = require('fs');
 
 class UnimplementedMethodError extends Error {
   constructor(message) {
@@ -102,7 +103,7 @@ class Distro {
       // The lines including a library has the following format: ' => /path/to/library.so'
       if (line.match(' => /')) {
         const lib = line.match(/ => ([^\s]*)/)[1];
-        result.push(lib);
+        nfile.isLink(lib) ? result.push(fs.realpathSync(lib)) : result.push(lib) ;
       }
     });
     return _.uniq(result);

--- a/lib/distro/distro.js
+++ b/lib/distro/distro.js
@@ -103,7 +103,9 @@ class Distro {
       // The lines including a library has the following format: ' => /path/to/library.so'
       if (line.match(' => /')) {
         const lib = line.match(/ => ([^\s]*)/)[1];
-        nfile.isLink(lib) ? result.push(fs.realpathSync(lib)) : result.push(lib) ;
+        /* eslint-disable no-unused-expressions */
+        nfile.isLink(lib) ? result.push(fs.realpathSync(lib)) : result.push(lib);
+        /* eslint-enable no-unused-expressions */
       }
     });
     return _.uniq(result);

--- a/lib/distro/index.js
+++ b/lib/distro/index.js
@@ -13,7 +13,7 @@ module.exports = {
         break;
       }
       case 'rhel': // RedHat
-      case 'amazon': // Amazon Linux
+      case 'amazonlinux': // Amazon Linux
       case 'ol': // Oracle Linux
       case 'centos': {
         result = new Centos(arch, options);

--- a/lib/distro/index.js
+++ b/lib/distro/index.js
@@ -7,11 +7,13 @@ module.exports = {
   getDistro: (distro, arch, options) => {
     let result = null;
     switch (distro) {
+      case 'ubuntu': // Ubuntu
       case 'debian': {
         result = new Debian(arch, options);
         break;
       }
       case 'rhel': // RedHat
+      case 'amazon': // Amazon Linux
       case 'ol': // Oracle Linux
       case 'centos': {
         result = new Centos(arch, options);

--- a/lib/distro/index.js
+++ b/lib/distro/index.js
@@ -7,7 +7,7 @@ module.exports = {
   getDistro: (distro, arch, options) => {
     let result = null;
     switch (distro) {
-      case 'ubuntu': // Ubuntu
+      case 'ubuntu':
       case 'debian': {
         result = new Debian(arch, options);
         break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.0.29",
+  "version": "2.1.0",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
This PRs adds support to compile on top of `ubuntu` and `amazon` systems.

Apart from that, I found some issues getting the package that contains a specific library if the library is a symlink. Because of that, I am using realpathSync to not use the symlink. Example:

```
bash-4.2# file /usr/lib64/libstdc++.so.6
/usr/lib64/libstdc++.so.6: symbolic link to libstdc++.so.6.0.24

bash-4.2# rpm -qf /usr/lib64/libstdc++.so.6
file /usr/lib64/libstdc++.so.6 is not owned by any package

bash-4.2# rpm -qf /usr/lib64/libstdc++.so.6.0.24
libstdc++72-7.2.1-2.59.amzn1.x86_64
```