### PR TITLE
Make yum install fail when trying to install missing packages

### DIFF
--- a/lib/distro/centos.js
+++ b/lib/distro/centos.js
@@ -28,8 +28,14 @@ class Centos extends Distro {
       'm'
     );
   }
+  _yumOptions() {
+    if (this._packageManagementTool === 'yum') {
+      return ['--setopt=skip_missing_names_on_install=False'];
+    }
+    return [];
+  }
   installCommand(pkgs) {
-    return `${this._packageManagementTool} install -y ${_.flatten([pkgs]).join(' ')}`;
+    return `${this._packageManagementTool} ${this._yumOptions().join(' ')} install -y ${_.flatten([pkgs]).join(' ')}`;
   }
   _getPkgNameFromDescriptor(descriptor) {
     return descriptor.match(/(.*?)-[0-9]/m)[1];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {

--- a/test/containerized-builder/image-provider/image-builder.js
+++ b/test/containerized-builder/image-provider/image-builder.js
@@ -41,7 +41,7 @@ describe('ImageBuilder', () => {
       expect(nfile.read(nfile.join(buildDir, 'Dockerfile'))).to.be.eql(
         `FROM test-image\n` +
         `RUN yum update -y\n` +
-        `RUN yum install -y zlib\n` +
+        `RUN yum --setopt=skip_missing_names_on_install=False install -y zlib\n` +
         `ENV PATH=$PATH:/test/bin\n` +
         `RUN install test\n`
       );

--- a/test/distro/centos.js
+++ b/test/distro/centos.js
@@ -40,9 +40,9 @@ describe('Centos', () => {
   });
   it('provides an install command', () => {
     const centos = new Centos('x64');
-    expect(centos.installCommand('zlib')).to.be.eql('yum install -y zlib');
+    expect(centos.installCommand('zlib')).to.be.eql('yum --setopt=skip_missing_names_on_install=False install -y zlib');
     expect(centos.installCommand(['zlib', 'openssl']))
-      .to.be.eql('yum install -y zlib openssl');
+      .to.be.eql('yum --setopt=skip_missing_names_on_install=False install -y zlib openssl');
   });
   it('returns a list of system packages given a list of files', () => {
     const centos = new Centos('x64');


### PR DESCRIPTION
When running `yum install` with a list of packages, the default behavior when some packages exist but others don't is to show a warning and continue, ending up with an exit code 0. This is particularly bad for containers, where we want to detect this at build time as soon as this is detected.

Enabling this `yum` option the following error is shown instead:

```Error: Not tolerating missing names on install, stopping.```