### PR TITLE
Update blacksmith-extra-component-types to v0.0.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "blacksmith",
-  "version": "2.1.10",
+  "version": "2.1.11",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {
     "node": "~6"
   },
   "dependencies": {
-    "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.39",
+    "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.40",
     "cmd-parser": "^0.0.1",
     "common-utils": "bitnami/node-common-utils#v2.2.0",
     "compilation-utils": "bitnami/node-compilation-utils#v1.0.4",


### PR DESCRIPTION
This release includes the changes from https://github.com/bitnami/blacksmith-extra-component-types/pull/41.