### PR TITLE
Add support for Photon OS compliation

### DIFF
--- a/lib/distro/centos.js
+++ b/lib/distro/centos.js
@@ -5,8 +5,8 @@ const Distro = require('./distro.js');
 const nos = require('nami-utils').os;
 
 /**
- * Interface representing a Debian Distro
- * @namespace BitnamiContainerizedBuilder.ImageProvider.Debian
+ * Interface representing a Centos Distro
+ * @namespace BitnamiContainerizedBuilder.ImageProvider.Centos
  * @extends BitnamiContainerizedBuilder.ImageProvider.Distro
  * @class
  * @param {string} image - Docker image of the distro

--- a/lib/distro/index.js
+++ b/lib/distro/index.js
@@ -2,6 +2,7 @@
 
 const Debian = require('./debian');
 const Centos = require('./centos');
+const Photon = require('./photon');
 
 module.exports = {
   getDistro: (distro, arch, options) => {
@@ -17,6 +18,10 @@ module.exports = {
       case 'ol': // Oracle Linux
       case 'centos': {
         result = new Centos(arch, options);
+        break;
+      }
+      case 'photon': {
+        result = new Photon(arch, options);
         break;
       }
       default: {

--- a/lib/distro/photon.js
+++ b/lib/distro/photon.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const Centos = require('./centos.js');
+
+/**
+ * Interface representing a Photon Distro
+ * @namespace BitnamiContainerizedBuilder.ImageProvider.Photon
+ * @extends BitnamiContainerizedBuilder.ImageProvider.Centos
+ * @class
+ * @param {string} image - Docker image of the distro
+ * @param {Object} [options]
+ * @param {Object} [options.logger] - Logger
+ * @property {Object} logger - Logger
+ * @property {Object} image - Docker image of the distro
+ * @property {Object} packageManagement - Package management tool of the distro
+ */
+class Photon extends Centos {
+  constructor(image, options) {
+    super(image, options);
+    this._packageManagementTool = 'tdnf';
+  }
+}
+
+module.exports = Photon;

--- a/lib/distro/photon.js
+++ b/lib/distro/photon.js
@@ -18,6 +18,7 @@ class Photon extends Centos {
   constructor(image, options) {
     super(image, options);
     this._packageManagementTool = 'tdnf';
+    // 'rpm' is still used as pkgProvider
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.1.12",
+  "version": "2.2.0",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Signed-off-by: tompizmor <tompizmor@gmail.com>

This PR adds support for using Photon as compilation target. The Photon OS is practically Centos but it uses an optimized system package manager (`tdnf`). `yum` also works but it does not include the `tdnf` optimizations. 