### PR TITLE
Only report AGPL links when AGPL components exist

### DIFF
--- a/lib/base-components/component.js
+++ b/lib/base-components/component.js
@@ -192,9 +192,8 @@ class Component {
           throw new Error(`You should specify either a licenseRelativePath or a licenseUrl for a CUSTOM license`);
         }
       }
-      const agplLinksFile = path.join(this.licenseDir, 'agpl-source-links.txt');
-      nfile.touch(agplLinksFile);
       if (this.mainLicense.type.match(/agpl/gi)) {
+        const agplLinksFile = path.join(this.licenseDir, 'agpl-source-links.txt');
         nfile.append(agplLinksFile, `${this.id}-${this.version},${this.mainLicense.type},${this.metadata.downloadURL}`);
       }
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Don't create an empty `agpl-source-links.txt` file if there are no AGPL components.