### PR TITLE
Upgrade node to v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-        - "6"
+        - "10"
 services:
   - docker
 script:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ const gulp = require('gulp');
 const commonTasks = require('bitnami-gulp-common-tasks')(gulp);
 const runSequence = require('run-sequence');
 
-const nodeVersion = '6.9.4';
+const nodeVersion = '10.19.0';
 
 /* CI tasks */
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {
-    "node": "~6"
+    "node": "~10"
   },
   "dependencies": {
     "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.49",


### PR DESCRIPTION
Summary:
v6.x is too old, many new deps as eslint fail to run on v6.x since it lacks support of some modern JS syntax.

I tried latest LTS v12 but I locked horns with gulp (see https://github.com/gulpjs/gulp/issues/2324).

I will try to modernise things more in future diffs, until I bring blacksmith on node v12.x LTS. One step at a time.