### PR TITLE
Bump release to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.4.2",
+  "version": "2.4.0",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Most important change in this release is the switch to node 10.x (#106)

It also contains a bunch of automatic npm package updates from dependabot