### PR TITLE
Rely primarily on readelf or objdump to identify dynamically linked binaries

### DIFF
--- a/lib/distro/distro.js
+++ b/lib/distro/distro.js
@@ -68,12 +68,29 @@ class Distro {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 
-  _getBinaryInfo(command, binary) {
-    // Support spaces and unscaped characters
-    const fileArgument = `'${binary}'`;
+  _getBinaryInfo(binary) {
     let result = '';
+    let infoCommand;
+    let infoCommandArgs;
+    if (nos.isInPath('readelf')) {
+      infoCommand = 'readelf';
+      infoCommandArgs = ['--file-header', '--dynamic', binary];
+    } else if (nos.isInPath('objdump')) {
+      infoCommand = 'objdump';
+      infoCommandArgs = ['-p', binary];
+    } else if (nos.isInPath('file')) {
+      // In some cases, 'file' may misidentify a dynamically linked .so library as being statically linked
+      this.logger.warn(
+        `Could not find recommended tools 'readelf' or 'objdump' to identify dynamically linked binaries. Falling back `
+        + `to less reliable 'file' tool.`
+      );
+      infoCommand = 'file';
+      infoCommandArgs = [binary];
+    } else {
+      throw new Error(`Commands 'readelf', 'objdump' or 'file' are required to obtain runtime packages.`);
+    }
     try {
-      result = nos.runProgram(command, fileArgument);
+      result = nos.runProgram(infoCommand, infoCommandArgs);
     } catch (e) {
       // Failed to parse the file as binary
     }
@@ -81,15 +98,11 @@ class Distro {
   }
 
   _getBinaries(files) {
-    if (!nos.isInPath('file') && !nos.isInPath('objdump')) {
-      throw new Error('Command "file" or "objdump" are needed to obtain runtime packages');
-    }
-    const infoCommand = nos.isInPath('file') ? 'file' : 'objdump';
     return _.filter(files, file => {
       if (!nfile.isLink(file) && nfile.isBinary(file)) {
-        const fileInfo = this._getBinaryInfo(infoCommand, file);
-        const extendedArch = ['x64', 'amd64', 'x86_64'].includes(this._arch) ? /(64-bit|elf64)/ : /(32-bit|elf32)/;
-        return fileInfo.match(/(dynamically linked|EXEC_P)/) && fileInfo.match(extendedArch);
+        const fileInfo = this._getBinaryInfo(file);
+        const extendedArch = ['x64', 'amd64', 'x86_64'].includes(this._arch) ? /(64-bit|elf64)/i : /(32-bit|elf32)/i;
+        return fileInfo.match(/(NEEDED|dynamically linked)/) && fileInfo.match(extendedArch);
       } else {
         return false;
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {

--- a/test/distro/centos.js
+++ b/test/distro/centos.js
@@ -17,6 +17,16 @@ describe('Centos', () => {
           text = `${args}: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, ` +
             `interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, BuildID[sha1]=12345, stripped`;
           break;
+        case 'objdump':
+          text = `${args}: file format elf64-x86-64\n\n` +
+              `Dynamic Section:\n` +
+              `NEEDED libc.so.6\n`;
+          break;
+        case 'readelf':
+          text = `ELF Header:\n` +
+              `Class: ELF64\n` +
+              `0x0000000000000001 (NEEDED) Shared library: [libc.so.6]\n`;
+          break;
         case 'ldd':
           text = 'libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f8526cd7000)' +
             '/lib64/ld-linux-x86-64.so.2 (0x000055e8c385d000)';

--- a/test/distro/debian.js
+++ b/test/distro/debian.js
@@ -19,9 +19,14 @@ describe('Debian', () => {
             `interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, BuildID[sha1]=12345, stripped`;
           break;
         case 'objdump':
-          text = `${args}: file format elf64-x86-64\n` +
-              `architecture: i386:x86-64, flags 0x00000112:\n` +
-              `EXEC_P, HAS_SYMS, D_PAGED\n`;
+          text = `${args}: file format elf64-x86-64\n\n` +
+              `Dynamic Section:\n` +
+              `NEEDED libc.so.6\n`;
+          break;
+        case 'readelf':
+          text = `ELF Header:\n` +
+              `Class: ELF64\n` +
+              `0x0000000000000001 (NEEDED) Shared library: [libc.so.6]\n`;
           break;
         case 'ldd':
           text = 'libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f8526cd7000)' +
@@ -64,6 +69,12 @@ describe('Debian', () => {
         it(`[${arch}] using "objdump"`, () => {
           nos.isInPath.restore();
           sinon.stub(nos, 'isInPath').callsFake(cmd => cmd === 'objdump');
+          const debian = new Debian(arch);
+          expect(debian.getRuntimePackages([path.join(__dirname, 'binary_sample')])).to.be.eql(['libc6']);
+        });
+        it(`[${arch}] using "readelf"`, () => {
+          nos.isInPath.restore();
+          sinon.stub(nos, 'isInPath').callsFake(cmd => cmd === 'readelf');
           const debian = new Debian(arch);
           expect(debian.getRuntimePackages([path.join(__dirname, 'binary_sample')])).to.be.eql(['libc6']);
         });


### PR DESCRIPTION
In some cases, 'file' may misidentify a dynamically linked .so library as being statically linked. See examples below:

* readelf: If it contains the "Dynamic" section it means it is dynamically linked. See example below:

    ```console
    $ readelf --file-header --dynamic lib/plugin/version_token.so
    ELF Header:
    Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00
    Class:                             ELF64
    ...
    Dynamic section at offset 0xcd00 contains 31 entries:
    Tag        Type                         Name/Value
    0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
    0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
    0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
    0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
    0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
    0x0000000000000001 (NEEDED)             Shared library: [ld-linux-x86-64.so.2]
    0x000000000000000f (RPATH)              Library rpath: [/opt/bitnami/mysql/lib/mysqlrouter:/opt/bitnami/mysql/lib]
    0x000000000000000c (INIT)               0x4000
    ...
    ```

    It would **not** contain that section if it weren't:

    ```console
    $ readelf -d /opt/bitnami/consul/bin/consul
    ELF Header:
      Magic:   7f 45 4c 46 02 01 01 00 00 00 00 00 00 00 00 00
      Class:                             ELF64
    ...

    There is no dynamic section in this file.
    ```

* objdump: Similar to readelf, it's just a fallback in case readelf is not available.

    ```console
    $ objdump -p lib/plugin/version_token.so

    lib/plugin/version_token.so:     file format elf64-x86-64

    Program Header:
      ...

    Dynamic Section:
    NEEDED               libpthread.so.0
    NEEDED               libstdc++.so.6
    NEEDED               libm.so.6
    NEEDED               libgcc_s.so.1
    NEEDED               libc.so.6
    NEEDED               ld-linux-x86-64.so.2
    RPATH                /opt/bitnami/mysql/lib/mysqlrouter:/opt/bitnami/mysql/lib
    ...
    ```

    If it were not statically linked it would not contain the "Dynamic" section:

    ```console
    $ objdump -p /opt/bitnami/consul/bin/consul

    /opt/bitnami/consul/bin/consul:     file format elf64-x86-64

    Program Header:
        ...
    ```

    (no "Dynamic Section")

* file thinks both are statically linked:

    ```console
    $ file lib/plugin/version_token.so
    lib/plugin/version_token.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), statically linked, BuildID[sha1]=726b5df751e09c0c287b0d1ba781e57d5cd3b41d, with debug_info, not stripped
    ```

    ```console
    $ file /opt/bitnami/consul/bin/consul
    /opt/bitnami/consul/bin/consul: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=G5GT24l8LtytGXx2uJCD/zVrf7RyekoVOiTBKIdVl/yxrrqwgmwKRi5M88yJ8K/IF-WPPUhKH_cWrVlENnn, not stripped
    ```

* (NOTE: ldd can know if binaries are dynamically linked, but not the arch:)

    ```console
    $ ldd lib/plugin/version_token.so
    	linux-vdso.so.1 (0x00007ffd699e2000)
    	libpthread.so.0 => /lib/libpthread.so.0 (0x00007f59c449e000)
    	...
    ```

    ```console
    $ ldd /opt/bitnami/consul/bin/consul
    	not a dynamic executable
    ```