### PR TITLE
Update extra component types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "blacksmith",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {
     "node": "~10"
   },
   "dependencies": {
-    "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.49",
+    "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.50",
     "cmd-parser": "^0.1.0",
     "common-utils": "bitnami/node-common-utils#v2.2.0",
     "compilation-utils": "bitnami/node-compilation-utils#v1.0.4",


### PR DESCRIPTION
This PR updates Blacksmith to use the latest "extra component types available" at https://github.com/bitnami/blacksmith-extra-component-type