### PR TITLE
Bump version of blacksmith-extra-components-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "blacksmith",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {
     "node": "~10"
   },
   "dependencies": {
-    "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.51",
+    "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.52",
     "cmd-parser": "^0.1.0",
     "common-utils": "bitnami/node-common-utils#v2.2.0",
     "compilation-utils": "bitnami/node-compilation-utils#v1.0.4",


### PR DESCRIPTION
Bump version of blacksmith-extra-components-types to use https://github.com/bitnami/blacksmith-extra-component-types/pull/54/