### PR TITLE
Don't remove libpg*.a files in minify method

### DIFF
--- a/lib/base-components/compilable-component.js
+++ b/lib/base-components/compilable-component.js
@@ -94,7 +94,7 @@ class CompilableComponent extends Component {
     this.logger.debug('Starting cleanup under', this.prefix);
     const files = nfile.glob(nfile.join(this.prefix, '**'));
     const toRemoveRegExps = [/.*\.a$/, /.*\.o$/, /.*\.la$/, /.*\.log$/];
-    const toKeepRegExps = [/.*ImageMagick.*/, /.*libruby-static\.a$/, /.*libv8.*\.a$/];
+    const toKeepRegExps = [/.*ImageMagick.*/, /.*libruby-static\.a$/, /.*libv8.*\.a$/, /.*libpg.*\.a$/];
     const docRegExps = [/.*\/docs?\//, /.*\/man\//];
     const match = (str, regexps) => {
       // Return true if str matches with any of the regexps

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.6.8",
+  "version": "2.6.9",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
`libpg*.a` files are useful static libraries for compiling extensions in PostgreSQL, so we should avoid removing them in a similar way than the Ruby static library.