### PR TITLE
Install Debian packages as noninteracive

### DIFF
--- a/lib/distro/debian.js
+++ b/lib/distro/debian.js
@@ -26,7 +26,8 @@ class Debian extends Distro {
     return new RegExp(`Package:\\s*${this._escapeRegExp(pkg)}\\s*\\nVersions:\\s*\\n([^\\s]*)`, 'm');
   }
   installCommand(pkgs) {
-    return `DEBIAN_FRONTEND="noninteractive" ${this._packageManagementTool} install -y --no-install-recommends ${_.flatten([pkgs]).join(' ')}`;
+    return 'DEBIAN_FRONTEND="noninteractive" ' +
+      `${this._packageManagementTool} install -y --no-install-recommends ${_.flatten([pkgs]).join(' ')}`;
   }
   _getPkgNameFromDescriptor(descriptor) {
     return descriptor.split(':')[0];

--- a/lib/distro/debian.js
+++ b/lib/distro/debian.js
@@ -26,7 +26,7 @@ class Debian extends Distro {
     return new RegExp(`Package:\\s*${this._escapeRegExp(pkg)}\\s*\\nVersions:\\s*\\n([^\\s]*)`, 'm');
   }
   installCommand(pkgs) {
-    return `${this._packageManagementTool} install -y --no-install-recommends ${_.flatten([pkgs]).join(' ')}`;
+    return `DEBIAN_FRONTEND="noninteractive" ${this._packageManagementTool} install -y --no-install-recommends ${_.flatten([pkgs]).join(' ')}`;
   }
   _getPkgNameFromDescriptor(descriptor) {
     return descriptor.split(':')[0];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.6.10",
+  "version": "2.6.11",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {

--- a/test/commands/build.js
+++ b/test/commands/build.js
@@ -42,7 +42,7 @@ describe('#build()', function() {
     }).to.throw(
       `Unable to parse ${inputsFile}. Received:\n` +
       `Invalid JSON for the schema build:\n` +
-      `instance additionalProperty "a" exists in instance when not allowed\n` +
+      `instance is not allowed to have the additional property "a"\n` +
       `instance requires property "components"\n`
     );
   });

--- a/test/commands/containerized-build.js
+++ b/test/commands/containerized-build.js
@@ -36,7 +36,7 @@ describe('#containerized-build()', function() {
     }).to.throw(
       `Unable to parse ${inputsFile}. Received:\n` +
       `Invalid JSON for the schema containerized-build:\n` +
-      `instance additionalProperty "a" exists in instance when not allowed\n` +
+      `instance is not allowed to have the additional property "a"\n` +
       `instance requires property "components"\n`
     );
   });

--- a/test/containerized-builder/image-provider/image-builder.js
+++ b/test/containerized-builder/image-provider/image-builder.js
@@ -72,7 +72,7 @@ describe('ImageBuilder', () => {
       expect(nfile.read(nfile.join(buildDir, 'Dockerfile'))).to.be.eql(
         `FROM test-image\n` +
         `RUN apt-get update -y\n` +
-        `RUN apt-get install -y --no-install-recommends zlib\n` +
+        `RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends zlib\n` +
         `ENV PATH=$PATH:/test/bin\n` +
         `RUN install test\n`
       );

--- a/test/distro/debian.js
+++ b/test/distro/debian.js
@@ -54,9 +54,9 @@ describe('Debian', () => {
   });
   it('provides an install command', () => {
     const debian = new Debian('x64');
-    expect(debian.installCommand('zlib')).to.be.eql('apt-get install -y --no-install-recommends zlib');
+    expect(debian.installCommand('zlib')).to.be.eql('DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends zlib');
     expect(debian.installCommand(['zlib', 'openssl']))
-      .to.be.eql('apt-get install -y --no-install-recommends zlib openssl');
+      .to.be.eql('DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends zlib openssl');
   });
   describe('returns a list of system packages given a list of files', () => {
     ['x64', 'amd64'].forEach(arch => {


### PR DESCRIPTION
We discovered that installing `tzdata`, a dialog is started and the base image can't be built.

Related: https://serverfault.com/a/992421

---

jsonschema changed the wording of one of the messages (https://github.com/tdegrunt/jsonschema/pull/298) and tests needed an update.