### PR TITLE
Add default function to remove pem files

### DIFF
--- a/lib/base-components/component.js
+++ b/lib/base-components/component.js
@@ -252,6 +252,17 @@ class Component {
    */
   postInstall() {}
   /**
+   * Remove Pem files hook. It will remove all the pem files by default
+   * @function BaseComponents.Component~removePemFiles
+   */
+  removePemFiles() {
+    const pemFiles = $file.glob('*.pem', {cwd: this.prefix, matchBase: true, absolutize: true});
+    this.logger.info(`The following .pem files were found and will be deleted: ${pemFiles}`);
+    pemFiles.forEach((file) => {
+      $file.delete(file);
+    });
+  }
+  /**
    * Post install clean up hook. No action will be taken by default.
    * @function BaseComponents.Component~minify
    */

--- a/lib/core/build-manager/index.js
+++ b/lib/core/build-manager/index.js
@@ -113,6 +113,7 @@ class BuildManager {
     obj.install();
     obj.fulfillLicenseRequirements();
     obj.postInstall();
+    obj.removePemFiles();
   }
 
   _buildComponents(components, options) {


### PR DESCRIPTION
This PR adds a function to remove `.pem` files during build time as the default behavior.
When a component needs those files it is possible to override the function and leave it empty.