### PR TITLE
Add Ubuntu 20.04 support with DebianLibSymlinked

### DIFF
--- a/lib/containerized-builder/image-provider/image-builder.js
+++ b/lib/containerized-builder/image-provider/image-builder.js
@@ -43,7 +43,7 @@ class ImageBuilder {
   }
 
   _writeDockerfile(dockerfile, baseImageID, buildTools, platform) {
-    const distro = distroFactory.getDistro(platform.distro, platform.arch);
+    const distro = distroFactory.getDistro(platform);
     let dockerfileText = `FROM ${baseImageID}\n`;
     if (_.some(buildTools, {type: 'system'})) {
       const systemPackages = _.map(_.filter(buildTools, {type: 'system'}), p => p.id);

--- a/lib/core/build-manager/artifacts/summary.js
+++ b/lib/core/build-manager/artifacts/summary.js
@@ -33,7 +33,7 @@ class Summary {
     this._artifactsDir = options.artifactsDir;
     this.id = options.buildId || strftime('build-%Y%m%d%H%M');
     this.platform = be.platform;
-    this.distro = distroFactory.getDistro(be.platform.distro, be.platform.arch, {logger: options.logger});
+    this.distro = distroFactory.getDistro(be.platform, {logger: options.logger});
     this.root = be.prefixDir;
     this.builtOn = new Date();
     this.artifacts = [];

--- a/lib/distro/debianlibsymlinked.js
+++ b/lib/distro/debianlibsymlinked.js
@@ -5,8 +5,8 @@ const Debian = require('./debian.js');
 
 /**
  * Interface representing a Debian Distro with the /lib folder symlinked to /usr/lib
- * This is the case of Distros like Ubuntu 20.04, and it requires a small adaptation in the
- * way the system packages are detected.
+ * This is the case of Distros like Ubuntu 20.04, and it requires a small
+ * adaptation in the way the system packages are detected.
  * @namespace BitnamiContainerizedBuilder.ImageProvider.DebianLibSymlinked
  * @extends BitnamiContainerizedBuilder.ImageProvider.Debian
  * @class
@@ -19,18 +19,22 @@ const Debian = require('./debian.js');
  */
 class DebianLibSymlinked extends Debian {
   /**
-   * Small fix for the `dpkg -S` command (used in the getRuntimePackages function) to work. As now all the `/lib` references will
-   * point to /usr/lib, the dpkg -S command may fail. For example:
-   *    dpkg -S libc.so
-   *    libc6:amd64: /lib/x86_64-linux-gnu/libc.so.6
+   * Small fix for the `dpkg -S` command (used in getRuntimePackages)
+   * to work. As now all the `/lib` references will point to /usr/lib,
+   * the dpkg -S command may fail. For example:
+   *   dpkg -S libc.so
+   *   libc6:amd64: /lib/x86_64-linux-gnu/libc.so.6
    * However, the _parseLibrariesInfo function would return this library path
-   *    /usr/lib/x86_64-linux-gnu/libc.so.6
+   *   /usr/lib/x86_64-linux-gnu/libc.so.6
    * That makes dpkg -S fail
-   *    dpkg -S /usr/lib/x86_64-linux-gnu/libc.so.6
-   *    dpkg-query: no path found matching pattern /usr/lib/x86_64-linux-gnu/libc.so.6
-   * It could happen the other way round, that a lib in `/lib` actually belongs to `/usr/lib`.
-   * There is no easy way to know if the system packages had `/lib` (example: glibc) or `/usr/lib` (example: libssl)
-   * so a way to workaround it is to substitute all `/usr/lib` and `/lib` references to `*\/lib`, which would match both paths
+   *   dpkg -S /usr/lib/x86_64-linux-gnu/libc.so.6
+   *   no path found matching pattern /usr/lib/x86_64-linux-gnu/libc.so.6
+   * It could happen the other way round, that a
+   * lib in `/lib` actually belongs to `/usr/lib`.
+   * There is no easy way to know if the system packages had
+   * `/lib` (example: glibc) or `/usr/lib` (example: libssl)
+   * so a way to workaround it is to substitute all `/usr/lib` and `/lib`
+   * references to `*\/lib`, which would match both paths
    *
    *    dpkg -S \*\/lib/x86_64-linux-gnu/libc.so.6
    *    libc6:amd64: /lib/x86_64-linux-gnu/libc.so.6

--- a/lib/distro/debianlibsymlinked.js
+++ b/lib/distro/debianlibsymlinked.js
@@ -41,7 +41,7 @@ class DebianLibSymlinked extends Debian {
   _parseLibrariesInfo(rawInfo) {
     return _.map(
       super._parseLibrariesInfo(rawInfo),
-      path => path.replace(/^([/]usr)?[/]lib/, '*/lib'),
+      path => path.replace(/^([/]usr)?[/]lib/, '*/lib')
     );
   }
 }

--- a/lib/distro/debianlibsymlinked.js
+++ b/lib/distro/debianlibsymlinked.js
@@ -18,10 +18,6 @@ const Debian = require('./debian.js');
  * @property {Object} packageManagement - Package management tool of the distro
  */
 class DebianLibSymlinked extends Debian {
-  constructor(image, options) {
-    super(image, options);
-  }
-
   /**
    * Small fix for the `dpkg -S` command (used in the getRuntimePackages function) to work. As now all the `/lib` references will
    * point to /usr/lib, the dpkg -S command may fail. For example:
@@ -43,7 +39,10 @@ class DebianLibSymlinked extends Debian {
    *    libssl1.1:amd64: /usr/lib/x86_64-linux-gnu/libssl.so.1.1
   */
   _parseLibrariesInfo(rawInfo) {
-    return _.map(super._parseLibrariesInfo(rawInfo), path => path.replace(/^([/]usr)?[/]lib/, '*/lib'));
+    return _.map(
+      super._parseLibrariesInfo(rawInfo),
+      path => path.replace(/^([/]usr)?[/]lib/, '*/lib'),
+    );
   }
 }
 module.exports = DebianLibSymlinked;

--- a/lib/distro/debianlibsymlinked.js
+++ b/lib/distro/debianlibsymlinked.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const _ = require('lodash');
+const Debian = require('./debian.js');
+
+/**
+ * Interface representing a Debian Distro with the /lib folder symlinked to /usr/lib
+ * This is the case of Distros like Ubuntu 20.04, and it requires a small adaptation in the
+ * way the system packages are detected.
+ * @namespace BitnamiContainerizedBuilder.ImageProvider.DebianLibSymlinked
+ * @extends BitnamiContainerizedBuilder.ImageProvider.Debian
+ * @class
+ * @param {string} image - Docker image of the distro
+ * @param {Object} [options]
+ * @param {Object} [options.logger] - Logger
+ * @property {Object} logger - Logger
+ * @property {Object} image - Docker image of the distro
+ * @property {Object} packageManagement - Package management tool of the distro
+ */
+class DebianLibSymlinked extends Debian {
+  constructor(image, options) {
+    super(image, options);
+  }
+
+  /**
+   * Small fix for the `dpkg -S` command (used in the getRuntimePackages function) to work. As now all the `/lib` references will
+   * point to /usr/lib, the dpkg -S command may fail. For example:
+   *    dpkg -S libc.so
+   *    libc6:amd64: /lib/x86_64-linux-gnu/libc.so.6
+   * However, the _parseLibrariesInfo function would return this library path
+   *    /usr/lib/x86_64-linux-gnu/libc.so.6
+   * That makes dpkg -S fail
+   *    dpkg -S /usr/lib/x86_64-linux-gnu/libc.so.6
+   *    dpkg-query: no path found matching pattern /usr/lib/x86_64-linux-gnu/libc.so.6
+   * It could happen the other way round, that a lib in `/lib` actually belongs to `/usr/lib`.
+   * There is no easy way to know if the system packages had `/lib` (example: glibc) or `/usr/lib` (example: libssl)
+   * so a way to workaround it is to substitute all `/usr/lib` and `/lib` references to `*\/lib`, which would match both paths
+   *
+   *    dpkg -S \*\/lib/x86_64-linux-gnu/libc.so.6
+   *    libc6:amd64: /lib/x86_64-linux-gnu/libc.so.6
+   *
+   *    dpkg -S \*\/lib/x86_64-linux-gnu/libssl.so.1.1
+   *    libssl1.1:amd64: /usr/lib/x86_64-linux-gnu/libssl.so.1.1
+  */
+  _parseLibrariesInfo(rawInfo) {
+    return _.map(super._parseLibrariesInfo(rawInfo), path => path.replace(/^([/]usr)?[/]lib/, '*/lib'));
+  }
+}
+module.exports = DebianLibSymlinked;

--- a/lib/distro/index.js
+++ b/lib/distro/index.js
@@ -3,29 +3,38 @@
 const Debian = require('./debian');
 const Centos = require('./centos');
 const Photon = require('./photon');
+const DebianLibSymlinked = require('./debianlibsymlinked');
 
 module.exports = {
-  getDistro: (distro, arch, options) => {
+  getDistro: (platform, options) => {
     let result = null;
-    switch (distro) {
-      case 'ubuntu':
+    switch (platform.distro) {
+      case 'ubuntu': {
+        if (platform.version === '20') {
+          // Ubuntu 20 has /lib symlinked to /usr/lib
+          result = new DebianLibSymlinked(platform.arch, options);
+        } else {
+          result = new Debian(platform.arch, options);
+        }
+        break;
+      }
       case 'debian': {
-        result = new Debian(arch, options);
+        result = new Debian(platform.arch, options);
         break;
       }
       case 'rhel': // RedHat
       case 'amazonlinux': // Amazon Linux
       case 'ol': // Oracle Linux
       case 'centos': {
-        result = new Centos(arch, options);
+        result = new Centos(platform.arch, options);
         break;
       }
       case 'photon': {
-        result = new Photon(arch, options);
+        result = new Photon(platform.arch, options);
         break;
       }
       default: {
-        throw new Error(`Distro type ${distro} is not supported`);
+        throw new Error(`Distro type ${platform.distro} is not supported`);
       }
     }
     return result;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.6.11",
+  "version": "2.7.0",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {

--- a/test/distro/debianlibsymlinked.js
+++ b/test/distro/debianlibsymlinked.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const Debian = require('../../lib/distro/debiansymlinked');
+const Debian = require('../../lib/distro/debianlibsymlinked');
 const chai = require('chai');
 const expect = chai.expect;
 const nos = require('nami-utils').os;
 const path = require('path');
 const sinon = require('sinon');
 
-describe('Debian Symlinked', () => {
+describe('Debian Lib Symlinked', () => {
   beforeEach(() => {
     sinon.stub(nos, 'isInPath').callsFake(() => true);
     sinon.stub(nos, 'runProgram').callsFake((command, args, options) => {

--- a/test/distro/debianlibsymlinked.js
+++ b/test/distro/debianlibsymlinked.js
@@ -96,5 +96,6 @@ describe('Debian Lib Symlinked', () => {
     const libInfo = debian._parseLibrariesInfo(sampleRawOutput);
     expect(libInfo.length).to.be.eql(2);
     expect(libInfo[0]).to.be.eql('*/lib/x86_64-linux-gnu/libcrypto.so.1.1');
+    expect(libInfo[1]).to.be.eql('*/lib/x86_64-linux-gnu/libpthread.so.0');
   });
 });

--- a/test/distro/debianlibsymlinked.js
+++ b/test/distro/debianlibsymlinked.js
@@ -87,7 +87,7 @@ describe('Debian Lib Symlinked', () => {
       {name: 'libcurl3:amd64', version: '7.38.0-4+deb8u5'},
     ]);
   });
-  it('/usr/lib references are changed to */lib', () => {
+  it('/usr/lib and /lib references are changed to */lib', () => {
     const debian = new Debian('x64');
     const sampleRawOutput = `
     libcrypto.so.1.1 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007f5d61d98000)

--- a/test/distro/debianlibsymlinked.js
+++ b/test/distro/debianlibsymlinked.js
@@ -91,11 +91,11 @@ describe('Debian Lib Symlinked', () => {
     const debian = new Debian('x64');
     const sampleRawOutput = `
     libcrypto.so.1.1 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007f5d61d98000)
-    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f5d61d75000)
+    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread-2.23.so(0x00007f5d61d75000)
     `;
     const libInfo = debian._parseLibrariesInfo(sampleRawOutput);
     expect(libInfo.length).to.be.eql(2);
     expect(libInfo[0]).to.be.eql('*/lib/x86_64-linux-gnu/libcrypto.so.1.1');
-    expect(libInfo[1]).to.be.eql('*/lib/x86_64-linux-gnu/libpthread.so.0');
+    expect(libInfo[1]).to.be.eql('*/lib/x86_64-linux-gnu/libpthread-2.23.so');
   });
 });

--- a/test/distro/debianlibsymlinked.js
+++ b/test/distro/debianlibsymlinked.js
@@ -91,7 +91,7 @@ describe('Debian Lib Symlinked', () => {
     const debian = new Debian('x64');
     const sampleRawOutput = `
     libcrypto.so.1.1 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007f5d61d98000)
-    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread-2.23.so(0x00007f5d61d75000)
+    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread-2.23.so (0x00007f5d61d75000)
     `;
     const libInfo = debian._parseLibrariesInfo(sampleRawOutput);
     expect(libInfo.length).to.be.eql(2);

--- a/test/distro/debiansymlinked.js
+++ b/test/distro/debiansymlinked.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const Debian = require('../../lib/distro/debiansymlinked');
+const chai = require('chai');
+const expect = chai.expect;
+const nos = require('nami-utils').os;
+const path = require('path');
+const sinon = require('sinon');
+
+describe('Debian Symlinked', () => {
+  beforeEach(() => {
+    sinon.stub(nos, 'isInPath').callsFake(() => true);
+    sinon.stub(nos, 'runProgram').callsFake((command, args, options) => {
+      options = options || {};
+      let text = '';
+      switch (command) {
+        case 'file':
+          text = `${args}: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, ` +
+            `interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.32, BuildID[sha1]=12345, stripped`;
+          break;
+        case 'objdump':
+          text = `${args}: file format elf64-x86-64\n\n` +
+              `Dynamic Section:\n` +
+              `NEEDED libc.so.6\n`;
+          break;
+        case 'readelf':
+          text = `ELF Header:\n` +
+              `Class: ELF64\n` +
+              `0x0000000000000001 (NEEDED) Shared library: [libc.so.6]\n`;
+          break;
+        case 'ldd':
+          text = 'libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f8526cd7000)' +
+            '/lib64/ld-linux-x86-64.so.2 (0x000055e8c385d000)';
+          break;
+        case 'dpkg':
+          text = 'libc6:amd64: /lib/x86_64-linux-gnu/libc.so.6\n';
+          break;
+        case 'dpkg-query':
+          text = 'libc6:amd64 2.19-18+deb8u7,libcurl3:amd64 7.38.0-4+deb8u5,';
+          break;
+        default:
+
+      }
+      return options.retrieveStdStreams ? {stdout: text} : text;
+    });
+  });
+  afterEach(() => {
+    nos.isInPath.restore();
+    nos.runProgram.restore();
+  });
+  it('provides an update command', () => {
+    const debian = new Debian('x64');
+    expect(debian.updateCommand).to.be.eql('apt-get update -y');
+  });
+  it('provides an install command', () => {
+    const debian = new Debian('x64');
+    expect(debian.installCommand('zlib')).to.be.eql('DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends zlib');
+    expect(debian.installCommand(['zlib', 'openssl']))
+      .to.be.eql('DEBIAN_FRONTEND="noninteractive" apt-get install -y --no-install-recommends zlib openssl');
+  });
+  describe('returns a list of system packages given a list of files', () => {
+    ['x64', 'amd64'].forEach(arch => {
+        it(`[${arch}] using "file"`, () => {
+          nos.isInPath.restore();
+          sinon.stub(nos, 'isInPath').callsFake(cmd => cmd === 'file');
+          const debian = new Debian(arch);
+          expect(debian.getRuntimePackages([path.join(__dirname, 'binary_sample')])).to.be.eql(['libc6']);
+        });
+        it(`[${arch}] using "objdump"`, () => {
+          nos.isInPath.restore();
+          sinon.stub(nos, 'isInPath').callsFake(cmd => cmd === 'objdump');
+          const debian = new Debian(arch);
+          expect(debian.getRuntimePackages([path.join(__dirname, 'binary_sample')])).to.be.eql(['libc6']);
+        });
+        it(`[${arch}] using "readelf"`, () => {
+          nos.isInPath.restore();
+          sinon.stub(nos, 'isInPath').callsFake(cmd => cmd === 'readelf');
+          const debian = new Debian(arch);
+          expect(debian.getRuntimePackages([path.join(__dirname, 'binary_sample')])).to.be.eql(['libc6']);
+        });
+    });
+  });
+  it('returns a list of system packages installed', () => {
+    const debian = new Debian('x64');
+    expect(debian.listPackages()).to.be.eql([
+      {name: 'libc6:amd64', version: '2.19-18+deb8u7'},
+      {name: 'libcurl3:amd64', version: '7.38.0-4+deb8u5'},
+    ]);
+  });
+  it('/usr/lib references are changed to */lib', () => {
+    const debian = new Debian('x64');
+    const sampleRawOutput = `
+    libcrypto.so.1.1 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007f5d61d98000)
+    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f5d61d75000)
+    `;
+    const libInfo = debian._parseLibrariesInfo(sampleRawOutput);
+    expect(libInfo.length).to.be.eql(2);
+    expect(libInfo[0]).to.be.eql('*/lib/x86_64-linux-gnu/libcrypto.so.1.1');
+  });
+});

--- a/test/distro/index.js
+++ b/test/distro/index.js
@@ -7,12 +7,12 @@ const expect = chai.expect;
 describe('Distro', () => {
   describe('Factory', () => {
     it('obtains a distribution', () => {
-      expect(() => distroFactory.getDistro('debian', 'x64')).to.not.throw();
-      expect(() => distroFactory.getDistro('debian', 'amd64')).to.not.throw();
-      expect(() => distroFactory.getDistro('centos', 'x86')).to.not.throw();
+      expect(() => distroFactory.getDistro({distro:'debian', arch: 'x64'}).to.not.throw();
+      expect(() => distroFactory.getDistro({distro:'debian', arch: 'x64'}).to.not.throw();
+      expect(() => distroFactory.getDistro({distro:'debian', arch: 'x64'}).to.not.throw();
     });
     it('throws an error for an unknown distro', () => {
-      expect(() => distroFactory.getDistro('??', 'x64')).to.throw('Distro type ?? is not supported');
+      expect(() => distroFactory.getDistro({distro: '??', arch: 'x64'}).to.throw('Distro type ?? is not supported');
     });
   });
 });

--- a/test/distro/index.js
+++ b/test/distro/index.js
@@ -7,12 +7,12 @@ const expect = chai.expect;
 describe('Distro', () => {
   describe('Factory', () => {
     it('obtains a distribution', () => {
-      expect(() => distroFactory.getDistro({distro:'debian', arch: 'x64'}).to.not.throw();
-      expect(() => distroFactory.getDistro({distro:'debian', arch: 'x64'}).to.not.throw();
-      expect(() => distroFactory.getDistro({distro:'debian', arch: 'x64'}).to.not.throw();
+      expect(() => distroFactory.getDistro({distro:'debian', arch: 'x64'}).to.not.throw());
+      expect(() => distroFactory.getDistro({distro:'debian', arch: 'x64'}).to.not.throw());
+      expect(() => distroFactory.getDistro({distro:'debian', arch: 'x64'}).to.not.throw());
     });
     it('throws an error for an unknown distro', () => {
-      expect(() => distroFactory.getDistro({distro: '??', arch: 'x64'}).to.throw('Distro type ?? is not supported');
+      expect(() => distroFactory.getDistro({distro: '??', arch: 'x64'}).to.throw('Distro type ?? is not supported'));
     });
   });
 });

--- a/test/distro/index.js
+++ b/test/distro/index.js
@@ -7,9 +7,9 @@ const expect = chai.expect;
 describe('Distro', () => {
   describe('Factory', () => {
     it('obtains a distribution', () => {
-      expect(() => distroFactory.getDistro({distro:'debian', arch: 'x64'}).to.not.throw());
-      expect(() => distroFactory.getDistro({distro:'debian', arch: 'x64'}).to.not.throw());
-      expect(() => distroFactory.getDistro({distro:'debian', arch: 'x64'}).to.not.throw());
+      expect(() => distroFactory.getDistro({distro: 'debian', arch: 'x64'}).to.not.throw());
+      expect(() => distroFactory.getDistro({distro: 'debian', arch: 'x64'}).to.not.throw());
+      expect(() => distroFactory.getDistro({distro: 'debian', arch: 'x64'}).to.not.throw());
     });
     it('throws an error for an unknown distro', () => {
       expect(() => distroFactory.getDistro({distro: '??', arch: 'x64'}).to.throw('Distro type ?? is not supported'));

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,7 @@ describe('Base Components', () => {
 
 describe('Distributions', () => {
   importTest('./distro/debian');
+  importTest('./distro/debiansymlinked');
   importTest('./distro/centos');
   importTest('./distro');
 });

--- a/test/index.js
+++ b/test/index.js
@@ -27,7 +27,7 @@ describe('Base Components', () => {
 
 describe('Distributions', () => {
   importTest('./distro/debian');
-  importTest('./distro/debiansymlinked');
+  importTest('./distro/debianlibsymlinked');
   importTest('./distro/centos');
   importTest('./distro');
 });


### PR DESCRIPTION
Distros like Ubuntu 20.04 have the following symlinks

```
root@a534523d3287:/# ls -l /
total 56
bin -> usr/bin
boot
dev
etc
home
lib -> usr/lib
lib32 -> usr/lib32
lib64 -> usr/lib64
libx32 -> usr/libx32
media
mnt
opt
proc
root
run
sbin -> usr/sbin
srv
sys
tmp
usr
var
```

This generates an issue with the `getRuntimePackages` function, as ldd detects all references in the `/lib` folder. Depending whether it is a symlink or not, the realpath function may calculate an incorrect library path (incorrect in the sense that `dpkg -S` would not recognize it). A way to workaround this is by creating a DebianLibSymlinked class (extending Debian), which performs a small change in the `_parseLibrariesInfo` function. For any `/lib` or `/usr/lib` reference, it would be changed to `*/lib`, which would be a format that `dpkg -S` accepts. 

We also needed to adapt the getDistro function so it can return a different distro object depending on the distro version.

This PR also adds proper testing to the class.  