### PR TITLE
Fix builds for projects that include a .git repo

### DIFF
--- a/lib/core/build-manager/artifacts/fstracker.js
+++ b/lib/core/build-manager/artifacts/fstracker.js
@@ -179,7 +179,8 @@ class FileSystemTracker {
     const res = nos.runProgram('git', ['commit', '-a', '-m', msg], {cwd: this._directory, retrieveStdStreams: true});
 
     if (res.code !== 0) {
-      if (!res.stdout.match('nothing to commit')) throw new Error(`Failed to commit: \n${res.stderr}`);
+      if (!res.stdout.match('nothing to commit') && !res.stdout.match('no changes added to commit'))
+        throw new Error(`Failed to commit: \n${res.stderr}`);
       return null;
     }
     return res.stdout.trim();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Some web applications recommend cloning the entire app directory as a .git repo, usually to simplify upgrades.

The problem is that Blacksmith is unable to detect changes in those directories with `fstracker`, throwing a `Failed to commit` error.

Context for fstracker: Blacksmith needs to determine files that have changed with respect to the builder image. To do this, it creates a `.git` folder inside the expected installation directory (i.e `/opt/bitnami`) and then checks the differences after building. It may also commit to check differences between steps.

With these changes, we're supposing that the changes inside directories with a Git repository (i.e. includes a `.git` folder) will be tracked as if they were not changed. Any change inside the Git repository will still be added to the artifacts though.