### PR TITLE
Fix jq logic from GH CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,11 +140,11 @@ jobs:
           \"platform\": \"linux-x64\", \
           \"s3Url\": \"${{ steps.s3path.outputs.s3path }}\", \
           \"checksum\": \"${{ steps.artifactChecksum.outputs.artifactChecksum }}\", \
-          \"bitnamiConfig\": \"${{ steps.s3ConfigPath.outputs.s3ConfigPath }}\"}" | jq .)]" >> metadata
+          \"bitnamiConfig\": \"${{ steps.s3ConfigPath.outputs.s3ConfigPath }}\"}" | jq .)]" >> updated_metadata
 
       - name: Upload configuration
         run: aws s3 cp config.json ${{ steps.s3ConfigPath.outputs.s3ConfigPath }}
       - name: Upload release tarball to s3
         run: aws s3 cp blacksmith-linux-x64.tar.gz ${{ steps.s3path.outputs.s3path }}
       - name: Upload updated metadata to s3
-        run: aws s3 cp metadata ${{ steps.s3MetadataPath.outputs.s3MetadataPath }}
+        run: aws s3 cp updated_metadata ${{ steps.s3MetadataPath.outputs.s3MetadataPath }}


### PR DESCRIPTION
The last few releases jobs have failed as they froze in the `New metadata` step because of an infinite loop introduced. Fixed logic so it works as expected. 

CI tested in a fork using a similar CI: https://github.com/FraPazGal/blacksmith/runs/2842533436?check_suite_focus=true