### PR TITLE
Improve copy dependencies method

### DIFF
--- a/docs/Blacksmith.md
+++ b/docs/Blacksmith.md
@@ -400,7 +400,6 @@ This class extends CompilableComponent and is used for building Ruby application
 * `additionalGems()`: List of extra Ruby gems to be downloaded when building the application. Defaults to empty array.
 * `install()`: Runs `gem install {{additionalGems()}}`, bundle install --binstubs --no-deployment` and `bundle install --binstubs --deployment --path vendor/bundle`. By default it will also install Phusion Passenger but can be disabled.
 * `minify()`: It will delete everything under the `log` and `vendor/bundle/ruby/*/cache` folders. It will also delete any precompiled binaries for `darwin`, `freebsd` and `i686` architectures.
-* `depsDir()`: defaults the dependencies folder to `ruby/lib/ruby/gems/*/gems` and `vendor/bundle/ruby/*/gems`.
 
 # Artifacts output folder
 

--- a/docs/Blacksmith.md
+++ b/docs/Blacksmith.md
@@ -224,6 +224,7 @@ All the classes will execute the following methods in order (they can be overrid
   * `fulfillLicenseRequirements`: Not need to override. If the license information is defined it checks if it is available in the source code and copies it in the component prefix in order to be included in the resulting tarball
   * `licenseFilename`: Not need to override. Set the name for the license file generated in `fulfillLicenseRequirements`.
   * `postInstall`: Can be overridden. Common tasks that execute after the install
+  * `copyComponentsWithDependencies`: Not need to override. Copy source code and dependencies to components-with-dependencies folder.
   * `minify`: Not need to override. Remove unnecesary files or folders and strip binary files generated
 
 ### Component
@@ -354,6 +355,7 @@ This class extends MakeComponent and is used for building Go applications. The f
 * `goBinaryPath()`: Returns the path to the Go binary folder to be set in the PATH environment variable.
 * `goImportPrefix()`: Name of the Go import. Used to define the source directory
 * `srcDir()`: defaults the source folder to goPath()/src/goImportPrefix()
+* `depsDir()`: defaults the dependencies folder to `go-app-scan-config`.
 * `getExportableEnvironmentVariables()`: Returns the `PATH` and `GOPATH` environment variables to be used with functions such as `runProgram`.
 * `configure()`: Empty method.
 
@@ -376,6 +378,7 @@ This class extends CompilableComponent and is used for building Node.js applicat
 * `build()`: Copies the source files to the installation prefix.
 * `additionalModules()`: List of extra npm modules necessary for the application to work. Defaults to an empty array.
 * `install()`: Runs `npm install --production --no-optional`, together with the list of extra modules defined in `additionalModules`.
+* `depsDir()`: defaults the dependencies folder to `node/lib/node_modules/<component.id>/node_modules` and `node_modules`.
 
 ### PhpApplication
 
@@ -397,6 +400,7 @@ This class extends CompilableComponent and is used for building Ruby application
 * `additionalGems()`: List of extra Ruby gems to be downloaded when building the application. Defaults to empty array.
 * `install()`: Runs `gem install {{additionalGems()}}`, bundle install --binstubs --no-deployment` and `bundle install --binstubs --deployment --path vendor/bundle`. By default it will also install Phusion Passenger but can be disabled.
 * `minify()`: It will delete everything under the `log` and `vendor/bundle/ruby/*/cache` folders. It will also delete any precompiled binaries for `darwin`, `freebsd` and `i686` architectures.
+* `depsDir()`: defaults the dependencies folder to `ruby/lib/ruby/gems/*/gems` and `vendor/bundle/ruby/*/gems`.
 
 # Artifacts output folder
 

--- a/lib/base-components/component.js
+++ b/lib/base-components/component.js
@@ -169,7 +169,7 @@ class Component {
       nfile.mkdir(depsDestinationDir);
       _.each(this.depsDir, d => {
         if (nfile.exists(d)) {
-          nfile.copy(d,depsDestinationDir, {exclude: this.excludeDir});
+          nfile.copy(d, depsDestinationDir, {exclude: this.excludeDir});
         }
       });
     }

--- a/lib/base-components/component.js
+++ b/lib/base-components/component.js
@@ -164,7 +164,7 @@ class Component {
     // Copy src code
     nfile.copy(nfile.join(this.be.sandboxDir, componentDir), srcAndDepsDir, {exclude: this.excludeDir});
     // Special case for components with same source code
-    if (this.id.toLowerCase() != this.metadata.id) {
+    if (this.id.toLowerCase() !== this.metadata.id) {
       nfile.move(nfile.join(srcAndDepsDir, componentDir),
                  nfile.join(srcAndDepsDir, `${this.metadata.id}-${this.version}`));
     }

--- a/lib/base-components/component.js
+++ b/lib/base-components/component.js
@@ -163,6 +163,11 @@ class Component {
     nfile.mkdir(srcAndDepsDir);
     // Copy src code
     nfile.copy(nfile.join(this.be.sandboxDir, componentDir), srcAndDepsDir, {exclude: this.excludeDir});
+    // Special case for components with same source code
+    if (this.id.toLowerCase() != this.metadata.id) {
+      nfile.move(nfile.join(srcAndDepsDir, componentDir),
+                 nfile.join(srcAndDepsDir, `${this.metadata.id}-${this.version}`));
+    }
     // Copy dependencies
     if (this.depsDir.length > 0) {
       const depsDestinationDir = path.join(srcAndDepsDir, componentDir, 'deps');

--- a/lib/base-components/component.js
+++ b/lib/base-components/component.js
@@ -94,6 +94,14 @@ class Component {
   }
 
   /**
+  * Get build excludeDir
+  * @returns {mixed}
+  */
+  get excludeDir() {
+    return [];
+  }
+
+  /**
   * Get build build dependencies of the component.
   * Note: This parameter is only used in containerized-builds
   * @returns {mixed}
@@ -146,16 +154,22 @@ class Component {
     }
   }
   /**
-   * Copy installed dependencies in depsDir to sandbox
-   * @function BaseComponents.Component~copyDependencies
+   * Copy source code and installed dependencies (depsDir) in components-with-deps folder
+   * @function BaseComponents.Component~copyComponentsWithDependencies
    */
-  copyDependencies() {
+  copyComponentsWithDependencies() {
+    const srcAndDepsDir = path.join(this.be.sandboxDir, 'components-with-deps');
+    const componentDir = `${this.id.toLowerCase()}-${this.version}`;
+    nfile.mkdir(srcAndDepsDir);
+    // Copy src code
+    nfile.copy(nfile.join(this.be.sandboxDir, componentDir), srcAndDepsDir, {exclude: this.excludeDir});
+    // Copy dependencies
     if (this.depsDir.length > 0) {
-      const sandboxDeps = path.join(this.be.sandboxDir, 'deps');
-      nfile.mkdir(sandboxDeps);
+      const depsDestinationDir = path.join(srcAndDepsDir, componentDir, 'deps');
+      nfile.mkdir(depsDestinationDir);
       _.each(this.depsDir, d => {
         if (nfile.exists(d)) {
-          nfile.copy(d, sandboxDeps);
+          nfile.copy(d,depsDestinationDir, {exclude: this.excludeDir});
         }
       });
     }

--- a/lib/core/build-manager/index.js
+++ b/lib/core/build-manager/index.js
@@ -113,7 +113,7 @@ class BuildManager {
     obj.install();
     obj.fulfillLicenseRequirements();
     obj.postInstall();
-    obj.copyDependencies();
+    obj.copyComponentsWithDependencies();
   }
 
   _buildComponents(components, options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "~10"
   },
   "dependencies": {
-    "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.65",
+    "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.66",
     "cmd-parser": "^0.1.0",
     "common-utils": "bitnami/node-common-utils#v2.2.0",
     "compilation-utils": "bitnami/node-compilation-utils#v1.0.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "~10"
   },
   "dependencies": {
-    "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.64",
+    "blacksmith-extra-component-types": "bitnami/blacksmith-extra-component-types#v0.0.65",
     "cmd-parser": "^0.1.0",
     "common-utils": "bitnami/node-common-utils#v2.2.0",
     "compilation-utils": "bitnami/node-compilation-utils#v1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.8.6",
+  "version": "2.8.7",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Now we are copying src code + dependencies to _components-with-deps_ folder inside sandbox.
It allows excluding directories too. 