### PR TITLE
Fix typo in copyComponentsWithDependencies method

### DIFF
--- a/lib/base-components/component.js
+++ b/lib/base-components/component.js
@@ -159,7 +159,7 @@ class Component {
    */
   copyComponentsWithDependencies() {
     const srcAndDepsDir = path.join(this.be.sandboxDir, 'components-with-deps');
-    const componentDir = `${this.id.toLowerCase()}-${this.version}`;
+    let componentDir = `${this.id.toLowerCase()}-${this.version}`;
     nfile.mkdir(srcAndDepsDir);
     // Copy src code
     nfile.copy(nfile.join(this.be.sandboxDir, componentDir), srcAndDepsDir, {exclude: this.excludeDir});
@@ -167,6 +167,7 @@ class Component {
     if (this.id.toLowerCase() !== this.metadata.id) {
       nfile.move(nfile.join(srcAndDepsDir, componentDir),
                  nfile.join(srcAndDepsDir, `${this.metadata.id}-${this.version}`));
+      componentDir = `${this.metadata.id}-${this.version}`;
     }
     // Copy dependencies
     if (this.depsDir.length > 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksmith",
-  "version": "2.8.7",
+  "version": "2.8.8",
   "description": "Bitnami Blacksmith System",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Fix typo in copyComponentsWithDependencies for the special case of components using same source code